### PR TITLE
Introduce -D ASYNCWEBSERVER_USE_CHUNK_INFLIGHT=0|1 to be able to enabled/disable inflight in chunk response

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,9 @@ jobs:
           - env: ci-arduino-3-no-json
             board: esp32dev
 
+          - env: ci-arduino-3-no-chunk-inflight
+            board: esp32dev
+
           - env: ci-esp8266
             board: huzzah
           - env: ci-esp8266

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
           - env: ci-arduino-3-no-json
             board: esp32dev
 
-          - env: ci-arduino-3-no-chunk-inflight
+          - env: ci-arduino-3-chunk-inflight
             board: esp32dev
 
           - env: ci-esp8266

--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ I personally use the following configuration in my projects:
   -D CONFIG_ASYNC_TCP_STACK_SIZE=4096     // reduce the stack size (default is 16K)
 ```
 
+If you need to server long / slow requests using chunk encoding (like fiel download from SD Card), you might need to set `-D ASYNCWEBSERVER_USE_CHUNK_INFLIGHT=1`.
+
 ## `AsyncWebSocketMessageBuffer` and `makeBuffer()`
 
 The fork from [yubox-node-org](https://github.com/yubox-node-org/ESPAsyncWebServer) introduces some breaking API changes compared to the original library, especially regarding the use of `std::shared_ptr<std::vector<uint8_t>>` for WebSocket.

--- a/platformio.ini
+++ b/platformio.ini
@@ -50,6 +50,10 @@ lib_deps =
 ; board = esp32-s3-devkitc-1
 ; board = esp32-c6-devkitc-1
 
+[env:arduino-3-no-chunk-inflight]
+build_flags = ${env.build_flags}
+  -D ASYNCWEBSERVER_USE_CHUNK_INFLIGHT=0
+
 [env:perf-test-AsyncTCP]
 build_flags = ${env.build_flags}
   -D PERF_TEST=1
@@ -93,6 +97,11 @@ board = ${sysenv.PIO_BOARD}
 board = ${sysenv.PIO_BOARD}
 lib_deps = 
   ESP32Async/AsyncTCP @ 3.3.2
+
+[env:ci-arduino-3-no-chunk-inflight]
+board = ${sysenv.PIO_BOARD}
+build_flags = ${env.build_flags}
+  -D ASYNCWEBSERVER_USE_CHUNK_INFLIGHT=0
 
 [env:ci-esp8266]
 platform = espressif8266

--- a/platformio.ini
+++ b/platformio.ini
@@ -50,9 +50,9 @@ lib_deps =
 ; board = esp32-s3-devkitc-1
 ; board = esp32-c6-devkitc-1
 
-[env:arduino-3-no-chunk-inflight]
+[env:arduino-3-chunk-inflight]
 build_flags = ${env.build_flags}
-  -D ASYNCWEBSERVER_USE_CHUNK_INFLIGHT=0
+  -D ASYNCWEBSERVER_USE_CHUNK_INFLIGHT=1
 
 [env:perf-test-AsyncTCP]
 build_flags = ${env.build_flags}
@@ -98,10 +98,10 @@ board = ${sysenv.PIO_BOARD}
 lib_deps = 
   ESP32Async/AsyncTCP @ 3.3.2
 
-[env:ci-arduino-3-no-chunk-inflight]
+[env:ci-arduino-3-chunk-inflight]
 board = ${sysenv.PIO_BOARD}
 build_flags = ${env.build_flags}
-  -D ASYNCWEBSERVER_USE_CHUNK_INFLIGHT=0
+  -D ASYNCWEBSERVER_USE_CHUNK_INFLIGHT=1
 
 [env:ci-esp8266]
 platform = espressif8266

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -60,6 +60,12 @@
   #define ASYNCWEBSERVER_REGEX_ATTRIBUTE __attribute__((warning("ASYNCWEBSERVER_REGEX not defined")))
 #endif
 
+// See https://github.com/ESP32Async/ESPAsyncWebServer/commit/3d3456e9e81502a477f6498c44d0691499dda8f9#diff-646b25b11691c11dce25529e3abce843f0ba4bd07ab75ec9eee7e72b06dbf13fR388-R392
+// This setting slowdown chunk serving but avoids crashing or deadlocks in the case where slow chunk responses are created, like file serving form SD Card
+#ifndef ASYNCWEBSERVER_USE_CHUNK_INFLIGHT
+  #define ASYNCWEBSERVER_USE_CHUNK_INFLIGHT 1
+#endif
+
 class AsyncWebServer;
 class AsyncWebServerRequest;
 class AsyncWebServerResponse;

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -63,7 +63,7 @@
 // See https://github.com/ESP32Async/ESPAsyncWebServer/commit/3d3456e9e81502a477f6498c44d0691499dda8f9#diff-646b25b11691c11dce25529e3abce843f0ba4bd07ab75ec9eee7e72b06dbf13fR388-R392
 // This setting slowdown chunk serving but avoids crashing or deadlocks in the case where slow chunk responses are created, like file serving form SD Card
 #ifndef ASYNCWEBSERVER_USE_CHUNK_INFLIGHT
-  #define ASYNCWEBSERVER_USE_CHUNK_INFLIGHT 1
+  #define ASYNCWEBSERVER_USE_CHUNK_INFLIGHT 0
 #endif
 
 class AsyncWebServer;

--- a/src/WebResponseImpl.h
+++ b/src/WebResponseImpl.h
@@ -47,10 +47,12 @@ class AsyncBasicResponse : public AsyncWebServerResponse {
 
 class AsyncAbstractResponse : public AsyncWebServerResponse {
   private:
+#if ASYNCWEBSERVER_USE_CHUNK_INFLIGHT
     // amount of responce data in-flight, i.e. sent, but not acked yet
     size_t _in_flight{0};
     // in-flight queue credits
     size_t _in_flight_credit{2};
+#endif
     String _head;
     // Data is inserted into cache at begin().
     // This is inefficient with vector, but if we use some other container,


### PR DESCRIPTION
`-D ASYNCWEBSERVER_USE_CHUNK_INFLIGHT=0` will disable inflight code in chunk responses and allow smaller chunk buffers to be used with higher number of concurrent chunk requests in the case of dat serving from (faster than sdcard) flash memory for example.

See: https://github.com/ESP32Async/ESPAsyncWebServer/issues/4