### PR TITLE
fix(http): Status 404 should be returned by default when no notFoundHandler is set. This is not an internal server error.

### DIFF
--- a/src/WebHandlers.cpp
+++ b/src/WebHandlers.cpp
@@ -299,7 +299,7 @@ void AsyncCallbackWebHandler::handleRequest(AsyncWebServerRequest *request) {
   if (_onRequest) {
     _onRequest(request);
   } else {
-    request->send(500);
+    request->send(404, T_text_plain, "Not found");
   }
 }
 void AsyncCallbackWebHandler::handleUpload(AsyncWebServerRequest *request, const String &filename, size_t index, uint8_t *data, size_t len, bool final) {


### PR DESCRIPTION
Just run:

`http://192.168.4.1/foo`

When `/foo` does not exist and no notFoundHalder is defined to reproduce the issue.