### PR TITLE
Reverted AsyncResponseStream buffer to cbuf which is considerably faster than StreamString

### DIFF
--- a/examples/AsyncResponseStream/AsyncResponseStream.ino
+++ b/examples/AsyncResponseStream/AsyncResponseStream.ino
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright 2016-2025 Hristo Gochkov, Mathieu Carbou, Emil Muratov
+
+#include <DNSServer.h>
+#ifdef ESP32
+#include <AsyncTCP.h>
+#include <WiFi.h>
+#elif defined(ESP8266)
+#include <ESP8266WiFi.h>
+#include <ESPAsyncTCP.h>
+#elif defined(TARGET_RP2040) || defined(TARGET_RP2350) || defined(PICO_RP2040) || defined(PICO_RP2350)
+#include <RPAsyncTCP.h>
+#include <WiFi.h>
+#endif
+
+#include <ESPAsyncWebServer.h>
+
+static AsyncWebServer server(80);
+
+void setup() {
+  Serial.begin(115200);
+
+#ifndef CONFIG_IDF_TARGET_ESP32H2
+  WiFi.mode(WIFI_AP);
+  WiFi.softAP("esp-captive");
+#endif
+
+  // Shows how to use AsyncResponseStream.
+  // The internal buffer will be allocated and data appended to it,
+  // until the response is sent, then this buffer is read and committed on the network.
+  //
+  // curl -v http://192.168.4.1/
+  //
+  server.on("/", HTTP_GET, [](AsyncWebServerRequest *request) {
+    AsyncResponseStream *response = request->beginResponseStream("plain/text", 40 * 1024);
+    for (int i = 0; i < 32 * 1024; i++) {
+      response->write('a');
+    }
+    request->send(response);
+  });
+
+  server.begin();
+}
+
+void loop() {
+  delay(100);
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,6 +1,7 @@
 [platformio]
 default_envs = arduino-2, arduino-3, esp8266, raspberrypi
 lib_dir = .
+; src_dir = examples/AsyncResponseStream
 ; src_dir = examples/Auth
 ; src_dir = examples/CaptivePortal
 ; src_dir = examples/CatchAllHandler
@@ -49,6 +50,7 @@ build_flags =
   -D CONFIG_ASYNC_TCP_QUEUE_SIZE=64
   -D CONFIG_ASYNC_TCP_RUNNING_CORE=1
   -D CONFIG_ASYNC_TCP_STACK_SIZE=4096
+  ; -D CONFIG_ASYNC_TCP_USE_WDT=0
 upload_protocol = esptool
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder, log2file

--- a/src/WebResponseImpl.h
+++ b/src/WebResponseImpl.h
@@ -10,7 +10,7 @@
 #undef max
 #endif
 #include "literals.h"
-#include <StreamString.h>
+#include <cbuf.h>
 #include <memory>
 #include <vector>
 
@@ -157,7 +157,7 @@ public:
 
 class AsyncResponseStream : public AsyncAbstractResponse, public Print {
 private:
-  StreamString _content;
+  std::unique_ptr<cbuf> _content;
 
 public:
   AsyncResponseStream(const char *contentType, size_t bufferSize);
@@ -172,7 +172,7 @@ public:
    * @brief Returns the number of bytes available in the stream.
    */
   size_t available() const {
-    return _content.length();  // note: _content.available() is not const
+    return _content->available();
   }
   using Print::write;
 };


### PR DESCRIPTION
This PR fixes an issue discovered in OpenDTU (see: https://github.com/tbnobody/OpenDTU/issues/2535).

The replacement of cbuf by StringStream is definitely slower (3-4 times). Even calling `setTimeout(0)` to inhibit the timed read with `readBytes()` does not help speeding up.

This PR reverts the code and also provides a MRE helping isolate the problem / reproduce it.

The use of `StringStream ` was causing several issues like:
- throttling within slow response (poll events)
- TWDT could trigger because of the slow StringStream

**Note: this issue is only visible for big payloads: this OpenDTU endpoints uses a buffer of 40k.**