### PR TITLE
Expose AsyncResponseStream::available()...

### DIFF
--- a/src/WebResponseImpl.h
+++ b/src/WebResponseImpl.h
@@ -168,6 +168,12 @@ public:
   size_t _fillBuffer(uint8_t *buf, size_t maxLen) override final;
   size_t write(const uint8_t *data, size_t len);
   size_t write(uint8_t data);
+  /**
+   * @brief Returns the number of bytes available in the stream.
+   */
+  size_t available() const {
+    return _content.length();  // note: _content.available() is not const
+  }
   using Print::write;
 };
 


### PR DESCRIPTION
... to get the number of bytes to be read in the temporary buffer, and to be sent on the wire for the response

Use case coming from OpenDTU project : https://github.com/tbnobody/OpenDTU/issues/2535#issuecomment-2784608721