### PR TITLE
Add LibreTiny support

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,18 @@ build_flags = ${env.build_flags}
   -Wno-missing-field-initializers
 ```
 
+**AsyncTCP-esphome**
+
+AsyncTCP-esphome replaces AsyncTCP to provide support for LibreTiny platform (BK72xx, RTL87xx). The dependency is automatically enabled with ESPAsyncWebServer.
+
+```ini
+platform = libretiny
+board = generic-bk7231n-tuya-qfn32
+lib_deps =
+  esphome/AsyncTCP-esphome@^2.1.4
+  ESP32Async/ESPAsyncWebServer
+```
+
 ## Important recommendations for build options
 
 Most of the crashes are caused by improper use or configuration of the AsyncTCP library used for the project.

--- a/library.json
+++ b/library.json
@@ -18,7 +18,8 @@
   "platforms": [
     "espressif32",
     "espressif8266",
-    "raspberrypi"
+    "raspberrypi",
+    "libretiny"
   ],
   "dependencies": [
     {
@@ -42,6 +43,12 @@
       "name": "RPAsyncTCP",
       "version": "^1.3.2",
       "platforms": "raspberrypi"
+    },
+    {
+      "owner": "esphome",
+      "name": "AsyncTCP-esphome",
+      "version": "^2.1.4",
+      "platforms": "libretiny"
     }
   ],
   "export": {

--- a/src/AsyncEventSource.h
+++ b/src/AsyncEventSource.h
@@ -6,7 +6,7 @@
 
 #include <Arduino.h>
 
-#ifdef ESP32
+#if defined(ESP32) || defined(LIBRETINY)
 #include <AsyncTCP.h>
 #include <mutex>
 #ifndef SSE_MAX_QUEUED_MESSAGES

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -17,6 +17,8 @@
 #include <rom/ets_sys.h>
 #elif defined(TARGET_RP2040) || defined(TARGET_RP2350) || defined(PICO_RP2040) || defined(PICO_RP2350) || defined(ESP8266)
 #include <Hash.h>
+#elif defined(LIBRETINY)
+#include <mbedtls/sha1.h>
 #endif
 
 using namespace asyncsrv;
@@ -1327,11 +1329,20 @@ AsyncWebSocketResponse::AsyncWebSocketResponse(const String &key, AsyncWebSocket
   }
   k.concat(key);
   k.concat(WS_STR_UUID);
+#ifdef LIBRETINY
+  mbedtls_sha1_context ctx;
+  mbedtls_sha1_init(&ctx);
+  mbedtls_sha1_starts(&ctx);
+  mbedtls_sha1_update(&ctx, (const uint8_t *)k.c_str(), k.length());
+  mbedtls_sha1_finish(&ctx, hash);
+  mbedtls_sha1_free(&ctx);
+#else
   SHA1Builder sha1;
   sha1.begin();
   sha1.add((const uint8_t *)k.c_str(), k.length());
   sha1.calculate();
   sha1.getBytes(hash);
+#endif
 #endif
   base64_encodestate _state;
   base64_init_encodestate(&_state);

--- a/src/AsyncWebSocket.h
+++ b/src/AsyncWebSocket.h
@@ -5,7 +5,8 @@
 #define ASYNCWEBSOCKET_H_
 
 #include <Arduino.h>
-#ifdef ESP32
+
+#if defined(ESP32) || defined(LIBRETINY)
 #include <AsyncTCP.h>
 #include <mutex>
 #ifndef WS_MAX_QUEUED_MESSAGES

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -15,7 +15,7 @@
 #include <unordered_map>
 #include <vector>
 
-#ifdef ESP32
+#if defined(ESP32) || defined(LIBRETINY)
 #include <AsyncTCP.h>
 #include <WiFi.h>
 #elif defined(ESP8266)
@@ -1100,7 +1100,7 @@ public:
   void end();
 
   tcp_state state() const {
-#ifdef ESP8266
+#if defined(ESP8266) || defined(LIBRETINY)
     // ESPAsyncTCP and RPAsyncTCP methods are not corrected declared with const for immutable ones.
     return static_cast<tcp_state>(const_cast<AsyncWebServer *>(this)->_server.status());
 #else

--- a/src/Middleware.cpp
+++ b/src/Middleware.cpp
@@ -172,7 +172,11 @@ void AsyncLoggingMiddleware::run(AsyncWebServerRequest *request, ArMiddlewareNex
     return;
   }
   _out->print(F("* Connection from "));
+#ifndef LIBRETINY
   _out->print(request->client()->remoteIP().toString());
+#else
+  _out->print(request->client()->remoteIP());
+#endif
   _out->print(':');
   _out->println(request->client()->remotePort());
   _out->print('>');

--- a/src/WebHandlers.cpp
+++ b/src/WebHandlers.cpp
@@ -209,11 +209,14 @@ void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest *request) {
     char buf[len];
     char *ret = lltoa(lw ^ request->_tempFile.size(), buf, len, 10);
     etag = ret ? String(ret) : String(request->_tempFile.size());
+#elif defined(LIBRETINY)
+    long val = lw ^ request->_tempFile.size();
+    etag = String(val);
 #else
     etag = lw ^ request->_tempFile.size();  // etag combines file size and lastmod timestamp
 #endif
   } else {
-#if defined(TARGET_RP2040) || defined(TARGET_RP2350) || defined(PICO_RP2040) || defined(PICO_RP2350)
+#if defined(TARGET_RP2040) || defined(TARGET_RP2350) || defined(PICO_RP2040) || defined(PICO_RP2350) || defined(LIBRETINY)
     etag = String(request->_tempFile.size());
 #else
     etag = request->_tempFile.size();

--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -394,7 +394,7 @@ bool AsyncWebServerRequest::_parseReqHeader() {
     }
     _headers.emplace_back(name, value);
   }
-#if defined(TARGET_RP2040) || defined(TARGET_RP2350) || defined(PICO_RP2040) || defined(PICO_RP2350)
+#if defined(TARGET_RP2040) || defined(TARGET_RP2350) || defined(PICO_RP2040) || defined(PICO_RP2350) || defined(LIBRETINY)
   // Ancient PRI core does not have String::clear() method 8-()
   _temp = emptyString;
 #else
@@ -419,7 +419,7 @@ void AsyncWebServerRequest::_parsePlainPostChar(uint8_t data) {
       _params.emplace_back(name, urlDecode(value), true);
     }
 
-#if defined(TARGET_RP2040) || defined(TARGET_RP2350) || defined(PICO_RP2040) || defined(PICO_RP2350)
+#if defined(TARGET_RP2040) || defined(TARGET_RP2350) || defined(PICO_RP2040) || defined(PICO_RP2350) || defined(LIBRETINY)
     // Ancient PRI core does not have String::clear() method 8-()
     _temp = emptyString;
 #else

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -4,6 +4,10 @@
 #include "ESPAsyncWebServer.h"
 #include "WebHandlerImpl.h"
 
+#ifdef LIBRETINY
+const String emptyStringForEspAsync;
+#endif
+
 using namespace asyncsrv;
 
 bool ON_STA_FILTER(AsyncWebServerRequest *request) {

--- a/src/literals.h
+++ b/src/literals.h
@@ -3,6 +3,11 @@
 
 #pragma once
 
+#ifdef LIBRETINY
+extern const String emptyStringForEspAsync;
+#define emptyString emptyStringForEspAsync
+#endif
+
 namespace asyncsrv {
 
 static constexpr const char *empty = "";


### PR DESCRIPTION
This PR introduces a series of non-breaking changes that make it possible to use latest ESPAsyncWebServer on LibreTiny platform (BK72xx, RTL87xx).

Previously, this was supported in https://github.com/esphome/ESPAsyncWebServer and used in ESPHome this way. That library is unmaintained, so I'm introducing support for LibreTiny in the updated version by ESP32Async. When it gets released, the web server used by ESPHome may be updated to ^v3.7.7 (in this PR: https://github.com/esphome/esphome/pull/8867).

The AsyncTCP implementation used for LibreTiny is https://github.com/esphome/AsyncTCP - it is the same one used for the few last years, so it's well-tested and stable.

This was tested and verified working on BK7231N.