### PR TITLE
 ETag and caching for serving pre‐compressed files

### DIFF
--- a/src/AsyncWebServerRequest.cpp
+++ b/src/AsyncWebServerRequest.cpp
@@ -1,13 +1,13 @@
- #include <ESPAsyncWebServer.h>
- 
- /**
+#include <ESPAsyncWebServer.h>
+
+/**
  * @brief Sends a file from the filesystem to the client, with optional gzip compression and ETag-based caching.
- * 
- * This method serves files over HTTP from the provided filesystem. If a compressed version of the file 
- * (with a `.gz` extension) exists and the `download` flag is not set, it serves the compressed file. 
+ *
+ * This method serves files over HTTP from the provided filesystem. If a compressed version of the file
+ * (with a `.gz` extension) exists and the `download` flag is not set, it serves the compressed file.
  * It also handles ETag caching using the CRC32 value from the gzip trailer, responding with `304 Not Modified`
  * if the client's `If-None-Match` header matches the generated ETag.
- * 
+ *
  * @param fs Reference to the filesystem (SPIFFS, LittleFS, etc.).
  * @param path Path to the file to be served.
  * @param contentType Optional MIME type of the file to be sent.
@@ -15,60 +15,60 @@
  * @param download If true, forces the file to be sent as a download (disables gzip compression).
  * @param callback Optional template processor for dynamic content generation.
  *                 Templates will not be processed in compressed files.
- * 
+ *
  * @note If neither the file nor its compressed version exists, responds with `404 Not Found`.
  */
- void AsyncWebServerRequest::send(FS &fs, const String &path, const char *contentType, bool download, AwsTemplateProcessor callback) {
-    const String gzPath = path + asyncsrv::T__gz;
-    const bool useCompressedVersion  = !download && fs.exists(gzPath);
+void AsyncWebServerRequest::send(FS &fs, const String &path, const char *contentType, bool download, AwsTemplateProcessor callback) {
+  const String gzPath = path + asyncsrv::T__gz;
+  const bool useCompressedVersion = !download && fs.exists(gzPath);
 
-    // If-None-Match header
-    if (useCompressedVersion && this->hasHeader(asyncsrv::T_INM)) {
-      // CRC32-based ETag of the trailer, bytes 4-7 from the end
-      File file = fs.open(gzPath, fs::FileOpenMode::read);
-      if (file && file.size() >= 18) {  // 18 is the minimum size of valid gzip file
-        file.seek(file.size() - 8);
+  // If-None-Match header
+  if (useCompressedVersion && this->hasHeader(asyncsrv::T_INM)) {
+    // CRC32-based ETag of the trailer, bytes 4-7 from the end
+    File file = fs.open(gzPath, fs::FileOpenMode::read);
+    if (file && file.size() >= 18) {  // 18 is the minimum size of valid gzip file
+      file.seek(file.size() - 8);
 
-        uint8_t crcFromGzipTrailer[4];
-        if (file.read(crcFromGzipTrailer, sizeof(crcFromGzipTrailer)) == sizeof(crcFromGzipTrailer)) {
-          char serverETag[9];
-          _getEtag(crcFromGzipTrailer, serverETag);
-          
-          // Compare with client's If-None-Match header
-          const AsyncWebHeader* inmHeader = this->getHeader(asyncsrv::T_INM);
-          if (inmHeader && inmHeader->value().equals(serverETag)) {
-            file.close();
-            this->send(304); // Not Modified
-            return;
-          }
+      uint8_t crcFromGzipTrailer[4];
+      if (file.read(crcFromGzipTrailer, sizeof(crcFromGzipTrailer)) == sizeof(crcFromGzipTrailer)) {
+        char serverETag[9];
+        _getEtag(crcFromGzipTrailer, serverETag);
+
+        // Compare with client's If-None-Match header
+        const AsyncWebHeader *inmHeader = this->getHeader(asyncsrv::T_INM);
+        if (inmHeader && inmHeader->value().equals(serverETag)) {
+          file.close();
+          this->send(304);  // Not Modified
+          return;
         }
-        file.close();
       }
-    }
-    
-    // If we get here, create and send the normal response
-    if (fs.exists(path) || useCompressedVersion) {
-      send(beginResponse(fs, path, contentType, download, callback));
-    } else {
-      send(404);
+      file.close();
     }
   }
 
+  // If we get here, create and send the normal response
+  if (fs.exists(path) || useCompressedVersion) {
+    send(beginResponse(fs, path, contentType, download, callback));
+  } else {
+    send(404);
+  }
+}
+
 /**
  * @brief Generates an ETag string from a 4-byte trailer using basic loop implementation
- * 
+ *
  * This function converts a 4-byte array into a hexadecimal ETag string enclosed in quotes.
- *  
+ *
  * @param trailer[4] Input array of 4 bytes to convert to hexadecimal
  * @param serverETag Output buffer to store the ETag
  *                   Must be pre-allocated with minimum 9 bytes (8 hex + 1 null terminator)
  */
-void AsyncWebServerRequest::_getEtag(uint8_t trailer[4], char* serverETag) {
+void AsyncWebServerRequest::_getEtag(uint8_t trailer[4], char *serverETag) {
   static constexpr char hexChars[] = "0123456789ABCDEF";
-  
+
   uint32_t data;
   memcpy(&data, trailer, 4);
-  
+
   serverETag[0] = hexChars[(data >> 4) & 0x0F];
   serverETag[1] = hexChars[data & 0x0F];
   serverETag[2] = hexChars[(data >> 12) & 0x0F];

--- a/src/AsyncWebServerRequest.cpp
+++ b/src/AsyncWebServerRequest.cpp
@@ -1,5 +1,23 @@
  #include <ESPAsyncWebServer.h>
  
+ /**
+ * @brief Sends a file from the filesystem to the client, with optional gzip compression and ETag-based caching.
+ * 
+ * This method serves files over HTTP from the provided filesystem. If a compressed version of the file 
+ * (with a `.gz` extension) exists and the `download` flag is not set, it serves the compressed file. 
+ * It also handles ETag caching using the CRC32 value from the gzip trailer, responding with `304 Not Modified`
+ * if the client's `If-None-Match` header matches the generated ETag.
+ * 
+ * @param fs Reference to the filesystem (SPIFFS, LittleFS, etc.).
+ * @param path Path to the file to be served.
+ * @param contentType Optional MIME type of the file to be sent.
+ *                    If contentType is "" it will be obtained from the file extension
+ * @param download If true, forces the file to be sent as a download (disables gzip compression).
+ * @param callback Optional template processor for dynamic content generation.
+ *                 Templates will not be processed in compressed files.
+ * 
+ * @note If neither the file nor its compressed version exists, responds with `404 Not Found`.
+ */
  void AsyncWebServerRequest::send(FS &fs, const String &path, const char *contentType, bool download, AwsTemplateProcessor callback) {
     const String gzPath = path + asyncsrv::T__gz;
     const bool useCompressedVersion  = !download && fs.exists(gzPath);
@@ -13,7 +31,7 @@
 
         uint8_t crcFromGzipTrailer[4];
         if (file.read(crcFromGzipTrailer, sizeof(crcFromGzipTrailer)) == sizeof(crcFromGzipTrailer)) {
-          char serverETag[11]; // " + 8 hex chars + " + '\0'
+          char serverETag[9];
           _getEtag(crcFromGzipTrailer, serverETag);
           
           // Compare with client's If-None-Match header
@@ -42,8 +60,8 @@
  * This function converts a 4-byte array into a hexadecimal ETag string enclosed in quotes.
  *  
  * @param trailer[4] Input array of 4 bytes to convert to hexadecimal
- * @param serverETag Output buffer that must be at least 11 bytes long to store the ETag
- *                   Must be pre-allocated with minimum 11 bytes (8 hex + 2 quotes + 1 null terminator)
+ * @param serverETag Output buffer to store the ETag
+ *                   Must be pre-allocated with minimum 9 bytes (8 hex + 1 null terminator)
  */
 void AsyncWebServerRequest::_getEtag(uint8_t trailer[4], char* serverETag) {
   static constexpr char hexChars[] = "0123456789ABCDEF";
@@ -51,15 +69,13 @@ void AsyncWebServerRequest::_getEtag(uint8_t trailer[4], char* serverETag) {
   uint32_t data;
   memcpy(&data, trailer, 4);
   
-  serverETag[0] = '"';
-  serverETag[1] = hexChars[(data >> 4) & 0x0F];
-  serverETag[2] = hexChars[data & 0x0F];
-  serverETag[3] = hexChars[(data >> 12) & 0x0F];
-  serverETag[4] = hexChars[(data >> 8) & 0x0F];
-  serverETag[5] = hexChars[(data >> 20) & 0x0F];
-  serverETag[6] = hexChars[(data >> 16) & 0x0F];
-  serverETag[7] = hexChars[(data >> 28)];
-  serverETag[8] = hexChars[(data >> 24) & 0x0F];
-  serverETag[9] = '"';
-  serverETag[10] = '\0';
+  serverETag[0] = hexChars[(data >> 4) & 0x0F];
+  serverETag[1] = hexChars[data & 0x0F];
+  serverETag[2] = hexChars[(data >> 12) & 0x0F];
+  serverETag[3] = hexChars[(data >> 8) & 0x0F];
+  serverETag[4] = hexChars[(data >> 20) & 0x0F];
+  serverETag[5] = hexChars[(data >> 16) & 0x0F];
+  serverETag[6] = hexChars[(data >> 28)];
+  serverETag[7] = hexChars[(data >> 24) & 0x0F];
+  serverETag[8] = '\0';
 }

--- a/src/AsyncWebServerRequest.cpp
+++ b/src/AsyncWebServerRequest.cpp
@@ -1,0 +1,65 @@
+ #include <ESPAsyncWebServer.h>
+ 
+ void AsyncWebServerRequest::send(FS &fs, const String &path, const char *contentType, bool download, AwsTemplateProcessor callback) {
+    const String gzPath = path + asyncsrv::T__gz;
+    const bool useCompressedVersion  = !download && fs.exists(gzPath);
+
+    // If-None-Match header
+    if (useCompressedVersion && this->hasHeader(asyncsrv::T_INM)) {
+      // CRC32-based ETag of the trailer, bytes 4-7 from the end
+      File file = fs.open(gzPath, fs::FileOpenMode::read);
+      if (file && file.size() >= 18) {  // 18 is the minimum size of valid gzip file
+        file.seek(file.size() - 8);
+
+        uint8_t crcFromGzipTrailer[4];
+        if (file.read(crcFromGzipTrailer, sizeof(crcFromGzipTrailer)) == sizeof(crcFromGzipTrailer)) {
+          char serverETag[11]; // " + 8 hex chars + " + '\0'
+          _getEtag(crcFromGzipTrailer, serverETag);
+          
+          // Compare with client's If-None-Match header
+          const AsyncWebHeader* inmHeader = this->getHeader(asyncsrv::T_INM);
+          if (inmHeader && inmHeader->value().equals(serverETag)) {
+            file.close();
+            this->send(304); // Not Modified
+            return;
+          }
+        }
+        file.close();
+      }
+    }
+    
+    // If we get here, create and send the normal response
+    if (fs.exists(path) || useCompressedVersion) {
+      send(beginResponse(fs, path, contentType, download, callback));
+    } else {
+      send(404);
+    }
+  }
+
+/**
+ * @brief Generates an ETag string from a 4-byte trailer using basic loop implementation
+ * 
+ * This function converts a 4-byte array into a hexadecimal ETag string enclosed in quotes.
+ *  
+ * @param trailer[4] Input array of 4 bytes to convert to hexadecimal
+ * @param serverETag Output buffer that must be at least 11 bytes long to store the ETag
+ *                   Must be pre-allocated with minimum 11 bytes (8 hex + 2 quotes + 1 null terminator)
+ */
+void AsyncWebServerRequest::_getEtag(uint8_t trailer[4], char* serverETag) {
+  static constexpr char hexChars[] = "0123456789ABCDEF";
+  
+  uint32_t data;
+  memcpy(&data, trailer, 4);
+  
+  serverETag[0] = '"';
+  serverETag[1] = hexChars[(data >> 4) & 0x0F];
+  serverETag[2] = hexChars[data & 0x0F];
+  serverETag[3] = hexChars[(data >> 12) & 0x0F];
+  serverETag[4] = hexChars[(data >> 8) & 0x0F];
+  serverETag[5] = hexChars[(data >> 20) & 0x0F];
+  serverETag[6] = hexChars[(data >> 16) & 0x0F];
+  serverETag[7] = hexChars[(data >> 28)];
+  serverETag[8] = hexChars[(data >> 24) & 0x0F];
+  serverETag[9] = '"';
+  serverETag[10] = '\0';
+}

--- a/src/AsyncWebServerRequest.cpp
+++ b/src/AsyncWebServerRequest.cpp
@@ -55,7 +55,7 @@ void AsyncWebServerRequest::send(FS &fs, const String &path, const char *content
 }
 
 /**
- * @brief Generates an ETag string from a 4-byte trailer using basic loop implementation
+ * @brief Generates an ETag string from a 4-byte trailer
  *
  * This function converts a 4-byte array into a hexadecimal ETag string enclosed in quotes.
  *

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -334,6 +334,8 @@ public:
   void addInterestingHeader(__unused const String &name) {
   }
 
+  static void _getEtag(uint8_t trailer[4], char* serverETag);
+
   /**
      * @brief issue HTTP redirect response with Location header
      *
@@ -367,13 +369,7 @@ public:
     send(beginResponse(code, contentType, content, len, callback));
   }
 
-  void send(FS &fs, const String &path, const char *contentType = asyncsrv::empty, bool download = false, AwsTemplateProcessor callback = nullptr) {
-    if (fs.exists(path) || (!download && fs.exists(path + asyncsrv::T__gz))) {
-      send(beginResponse(fs, path, contentType, download, callback));
-    } else {
-      send(404);
-    }
-  }
+  void send(FS &fs, const String &path, const char *contentType = asyncsrv::empty, bool download = false, AwsTemplateProcessor callback = nullptr);
   void send(FS &fs, const String &path, const String &contentType, bool download = false, AwsTemplateProcessor callback = nullptr) {
     send(fs, path, contentType.c_str(), download, callback);
   }

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -203,6 +203,7 @@ class AsyncWebServerRequest {
   using FS = fs::FS;
   friend class AsyncWebServer;
   friend class AsyncCallbackWebHandler;
+  friend class AsyncFileResponse;
 
 private:
   AsyncClient *_client;
@@ -273,6 +274,8 @@ private:
 
   void _send();
   void _runMiddlewareChain();
+
+  static void _getEtag(uint8_t trailer[4], char *serverETag);
 
 public:
   File _tempFile;
@@ -352,8 +355,6 @@ public:
 #endif
   void addInterestingHeader(__unused const String &name) {
   }
-
-  static void _getEtag(uint8_t trailer[4], char *serverETag);
 
   /**
      * @brief issue HTTP redirect response with Location header

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -353,7 +353,7 @@ public:
   void addInterestingHeader(__unused const String &name) {
   }
 
-  static void _getEtag(uint8_t trailer[4], char* serverETag);
+  static void _getEtag(uint8_t trailer[4], char *serverETag);
 
   /**
      * @brief issue HTTP redirect response with Location header

--- a/src/WebResponses.cpp
+++ b/src/WebResponses.cpp
@@ -680,7 +680,7 @@ AsyncFileResponse::AsyncFileResponse(FS &fs, const String &path, const char *con
     _content = fs.open(gzPath, fs::FileOpenMode::read);
     _contentLength = _content.size();
     addHeader(T_Content_Encoding, T_gzip, false);
-    _callback = nullptr; // Unable to process zipped templates
+    _callback = nullptr;  // Unable to process zipped templates
     _sendContentLength = true;
     _chunked = false;
 
@@ -706,8 +706,7 @@ AsyncFileResponse::AsyncFileResponse(FS &fs, const String &path, const char *con
 
   if (*contentType != '\0') {
     _setContentTypeFromPath(path);
-  }
-  else {
+  } else {
     _contentType = contentType;
   }
 
@@ -718,8 +717,7 @@ AsyncFileResponse::AsyncFileResponse(FS &fs, const String &path, const char *con
   if (download) {
     // set filename and force download
     snprintf_P(buf, sizeof(buf), PSTR("attachment; filename=\"%s\""), filename);
-  }
-  else {
+  } else {
     // set filename and force rendering
     snprintf_P(buf, sizeof(buf), PSTR("inline"));
   }

--- a/src/WebResponses.cpp
+++ b/src/WebResponses.cpp
@@ -688,7 +688,7 @@ AsyncFileResponse::AsyncFileResponse(FS &fs, const String &path, const char *con
     _content.seek(_contentLength - 8);
     uint8_t crcInTrailer[4];
     if (_content.read(crcInTrailer, sizeof(crcInTrailer)) == sizeof(crcInTrailer)) {
-      char serverETag[11];
+      char serverETag[9];
       AsyncWebServerRequest::_getEtag(crcInTrailer, serverETag);
       addHeader(T_ETag, serverETag, false);
       addHeader(T_Cache_Control, T_no_cache, false);

--- a/src/WebResponses.cpp
+++ b/src/WebResponses.cpp
@@ -649,22 +649,41 @@ void AsyncFileResponse::_setContentTypeFromPath(const String &path) {
 AsyncFileResponse::AsyncFileResponse(FS &fs, const String &path, const char *contentType, bool download, AwsTemplateProcessor callback)
   : AsyncAbstractResponse(callback) {
   _code = 200;
-  _path = path;
+  const String gzPath = path + asyncsrv::T__gz;
 
-  if (!download && !fs.exists(_path) && fs.exists(_path + T__gz)) {
-    _path = _path + T__gz;
+  if (!download && !fs.exists(path) && fs.exists(gzPath)) {
+    _path = gzPath;
+    _content = fs.open(gzPath, fs::FileOpenMode::read);
+    _contentLength = _content.size();
     addHeader(T_Content_Encoding, T_gzip, false);
-    _callback = nullptr;  // Unable to process zipped templates
+    _callback = nullptr; // Unable to process zipped templates
     _sendContentLength = true;
     _chunked = false;
+
+    // CRC32-based ETag of the trailer, bytes 4-7 from the end
+    _content.seek(_contentLength - 8);
+    uint8_t crcInTrailer[4];
+    if (_content.read(crcInTrailer, sizeof(crcInTrailer)) == sizeof(crcInTrailer)) {
+      char serverETag[11];
+      AsyncWebServerRequest::_getEtag(crcInTrailer, serverETag);
+      addHeader(T_ETag, serverETag, false);
+      addHeader(T_Cache_Control, T_no_cache, false);
+    }
+
+    // Return to the beginning of the file
+    _content.seek(0);
   }
 
-  _content = fs.open(_path, fs::FileOpenMode::read);
-  _contentLength = _content.size();
+  if (!_content) {
+    _path = path;
+    _content = fs.open(path, fs::FileOpenMode::read);
+    _contentLength = _content.size();
+  }
 
-  if (strlen(contentType) == 0) {
+  if (*contentType != '\0') {
     _setContentTypeFromPath(path);
-  } else {
+  }
+  else {
     _contentType = contentType;
   }
 
@@ -675,7 +694,8 @@ AsyncFileResponse::AsyncFileResponse(FS &fs, const String &path, const char *con
   if (download) {
     // set filename and force download
     snprintf_P(buf, sizeof(buf), PSTR("attachment; filename=\"%s\""), filename);
-  } else {
+  }
+  else {
     // set filename and force rendering
     snprintf_P(buf, sizeof(buf), PSTR("inline"));
   }


### PR DESCRIPTION
This PR brings improved standards-compliant handling of pre-compressed .gz files, providing ETag support and conditional responses, helping optimize client-side caching and server resource usage. Fully backward compatible.

ETag Generation for Pre-compressed .gz Files

When a .gz file is served via AsyncFileResponse, the server now generates an ETag header based on the CRC32 checksum found ((first 4 bytes) in the gzip trailer (last 8 bytes of gz file).
A Cache-Control: no-cache header is also added to enforce proper cache validation.
Conditional Request Support in send()

The send() method now checks for the If-None-Match header when a .gz version of the requested file exists.
If the client's ETag matches the server's ETag (derived from the gzip trailer), the server responds with 304 Not Modified, saving bandwidth and improving efficiency.
If the ETag does not match or no valid ETag is present, the normal file response is sent.
These changes only apply to pre-compressed .gz files and do not alter the behavior for uncompressed files.

Why this is useful?

For static resources, improves client-side caching efficiency by allowing conditional requests with If-None-Match
Reduces unnecessary re-downloads of static resources when they haven't changed
Aligns with common web best practices for serving compressed assets with proper cache validation.
ETag values are derived from the CRC32 checksum embedded in the gzip trailer, ensuring the ETag reflects the original uncompressed content. If change the uncompressed content, change the Etag.
It is fully backward compatible. It has no adverse effects on library users and does not require them to modify their code.