### PR TITLE
Fix client rx timeout

### DIFF
--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -92,7 +92,7 @@ public:
 #endif
 
 // if this value is returned when asked for data, packet will not be sent and you will be asked for data again
-#define RESPONSE_TRY_AGAIN          0xFFFFFFFF
+#define RESPONSE_TRY_AGAIN 0xFFFFFFFF
 
 #ifndef CONFIG_TCP_MSS
 #define RESPONSE_STREAM_BUFFER_SIZE 1460

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -44,6 +44,10 @@
 #define ASYNCWEBSERVER_USE_CHUNK_INFLIGHT 1
 #endif
 
+#ifndef ASYNCWEBSERVER_RX_TIMEOUT
+#define ASYNCWEBSERVER_RX_TIMEOUT 3  // Seconds for timeout
+#endif
+
 class AsyncWebServer;
 class AsyncWebServerRequest;
 class AsyncWebServerResponse;
@@ -88,7 +92,7 @@ public:
 
 // if this value is returned when asked for data, packet will not be sent and you will be asked for data again
 #define RESPONSE_TRY_AGAIN          0xFFFFFFFF
-#define RESPONSE_STREAM_BUFFER_SIZE 1460
+#define RESPONSE_STREAM_BUFFER_SIZE CONFIG_TCP_MSS
 
 typedef uint8_t WebRequestMethodComposite;
 typedef std::function<void(void)> ArDisconnectHandler;
@@ -250,6 +254,7 @@ private:
   String _itemValue;
   uint8_t *_itemBuffer;
   size_t _itemBufferIndex;
+  uint32_t _rx_timeout;
   bool _itemIsFile;
 
   void _onPoll();

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -16,6 +16,7 @@
 #include <vector>
 
 #if defined(ESP32) || defined(LIBRETINY)
+#include "sdkconfig.h"
 #include <AsyncTCP.h>
 #elif defined(ESP8266)
 #include <ESPAsyncTCP.h>
@@ -92,7 +93,12 @@ public:
 
 // if this value is returned when asked for data, packet will not be sent and you will be asked for data again
 #define RESPONSE_TRY_AGAIN          0xFFFFFFFF
+
+#ifndef CONFIG_TCP_MSS
+#define RESPONSE_STREAM_BUFFER_SIZE 1460
+#else
 #define RESPONSE_STREAM_BUFFER_SIZE CONFIG_TCP_MSS
+#endif
 
 typedef uint8_t WebRequestMethodComposite;
 typedef std::function<void(void)> ArDisconnectHandler;

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -16,7 +16,9 @@
 #include <vector>
 
 #if defined(ESP32) || defined(LIBRETINY)
+#ifdef ESP32
 #include "sdkconfig.h"
+#endif
 #include <AsyncTCP.h>
 #elif defined(ESP8266)
 #include <ESPAsyncTCP.h>

--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -25,7 +25,7 @@ AsyncWebServerRequest::AsyncWebServerRequest(AsyncWebServer *s, AsyncClient *c)
   : _client(c), _server(s), _handler(NULL), _response(NULL), _onDisconnectfn(NULL), _temp(), _parseState(PARSE_REQ_START), _version(0), _method(HTTP_ANY),
     _url(), _host(), _contentType(), _boundary(), _authorization(), _reqconntype(RCT_HTTP), _authMethod(AsyncAuthType::AUTH_NONE), _isMultipart(false),
     _isPlainPost(false), _expectingContinue(false), _contentLength(0), _parsedLength(0), _multiParseState(0), _boundaryPosition(0), _itemStartIndex(0),
-    _itemSize(0), _itemName(), _itemFilename(), _itemType(), _itemValue(), _itemBuffer(0), _itemBufferIndex(0), _itemIsFile(false), _tempObject(NULL) {
+    _itemSize(0), _itemName(), _itemFilename(), _itemType(), _itemValue(), _itemBuffer(0), _itemBufferIndex(0), _itemIsFile(false), _tempObject(NULL), _rx_timeout(ASYNCWEBSERVER_RX_TIMEOUT) {
   c->onError(
     [](void *r, AsyncClient *c, int8_t error) {
       (void)c;
@@ -720,7 +720,6 @@ void AsyncWebServerRequest::_send() {
     }
 
     // here, we either have a response give nfrom user or one of the two above
-    _client->setRxTimeout(0);
     _response->_respond(this);
     _sent = true;
   }
@@ -730,6 +729,7 @@ AsyncWebServerRequestPtr AsyncWebServerRequest::pause() {
   if (_paused) {
     return _this;
   }
+  _rx_timeout = client()->getRxTimeout(); // backup client rx timeout
   client()->setRxTimeout(0);
   // this shared ptr will hold the request pointer until it gets destroyed following a disconnect.
   // this is just used as a holder providing weak observers, so the deleter is a no-op.
@@ -937,6 +937,7 @@ void AsyncWebServerRequest::send(AsyncWebServerResponse *response) {
   // if request was paused, we need to send the response now
   if (_paused) {
     _paused = false;
+    _client->setRxTimeout(_rx_timeout); // restore rx timeout
     _send();
   }
 }

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -43,7 +43,7 @@ AsyncWebServer::AsyncWebServer(uint16_t port) : _server(port) {
       if (c == NULL) {
         return;
       }
-      c->setRxTimeout(3);
+      c->setRxTimeout(ASYNCWEBSERVER_RX_TIMEOUT);
       AsyncWebServerRequest *r = new AsyncWebServerRequest((AsyncWebServer *)s, c);
       if (r == NULL) {
         c->abort();


### PR DESCRIPTION
- The client RX timeout is always set to 0 (disabled) in the _send() function