### PR TITLE
Fix bug. Sometimes the content type isn't sent.

### DIFF
--- a/src/AsyncWebServerRequest.cpp
+++ b/src/AsyncWebServerRequest.cpp
@@ -27,7 +27,7 @@ void AsyncWebServerRequest::send(FS &fs, const String &path, const char *content
 
   // Handle compressed version
   const String gzPath = path + asyncsrv::T__gz;
-  File gzFile = fs.open(gzPath, "r");
+  File gzFile = fs.open(gzPath, fs::FileOpenMode::read);
 
   // Compressed file not found or invalid
   if (!gzFile.seek(gzFile.size() - 8)) {

--- a/src/WebResponses.cpp
+++ b/src/WebResponses.cpp
@@ -734,7 +734,7 @@ AsyncFileResponse::AsyncFileResponse(FS &fs, const String &path, const char *con
     }
   }
 
-  if (*contentType != '\0') {
+  if (*contentType == '\0') {
     _setContentTypeFromPath(path);
   } else {
     _contentType = contentType;
@@ -745,11 +745,11 @@ AsyncFileResponse::AsyncFileResponse(FS &fs, const String &path, const char *con
     int filenameStart = path.lastIndexOf('/') + 1;
     char buf[26 + path.length() - filenameStart];
     char *filename = (char *)path.c_str() + filenameStart;
-    snprintf_P(buf, sizeof(buf), PSTR("attachment; filename=\"%s\""), filename);
+    snprintf(buf, sizeof(buf), T_attachment, filename);
     addHeader(T_Content_Disposition, buf, false);
   } else {
     // Serve file inline (display in browser)
-    addHeader(T_Content_Disposition, PSTR("inline"), false);
+    addHeader(T_Content_Disposition, T_inline, false);
   }
 
   _code = 200;

--- a/src/literals.h
+++ b/src/literals.h
@@ -7,6 +7,9 @@ namespace asyncsrv {
 
 static constexpr const char *empty = "";
 
+static const char T_inline[] = "inline";
+static const char T_attachment[] = "attachment; filename=\"%s\"";
+
 static constexpr const char *T__opaque = "\", opaque=\"";
 static constexpr const char *T_100_CONTINUE = "100-continue";
 static constexpr const char *T_13 = "13";


### PR DESCRIPTION
Fixes an regresive bug where Content-Type was not properly set when serving files, which specifically affected Firefox when using "view page source" functionality. The issue primarily manifested in Firefox's view-source feature, but the fix ensures consistent behavior across all browsers and use cases.

Changes:
Fixed missing contentType headers
Optimized string handling by replacing PSTR() with static constant
- Optimized string handling by replacing snprintf_P with snprintf
- Changed from dynamic buffer formatting to direct header addition using static template
- Improved memory efficiency and code readability