### PR TITLE
Refactor AsyncFileResponse: remove String _path

### DIFF
--- a/src/WebResponseImpl.h
+++ b/src/WebResponseImpl.h
@@ -75,7 +75,6 @@ class AsyncFileResponse : public AsyncAbstractResponse {
 
 private:
   File _content;
-  String _path;
   void _setContentTypeFromPath(const String &path);
 
 public:


### PR DESCRIPTION
This refactor eliminates the private String _path member from the AsyncFileResponse class, replacing its functionality with a fixed-size char gzPath[MAX_PATH] buffer insife of function.

The use of Arduino's dynamic String class has known drawbacks in memory-constrained or real-time systems, particularly due to heap fragmentation and unpredictable allocation behavior. By switching to a statically allocated C-style buffer, the implementation now benefits from improved memory determinism, reduced fragmentation risk, and overall lower memory overhead. In addition to reducing memory fragmentation and improving stability in embedded environments, this change also yields better execution speed. This change maintains behavioral equivalence.