### PR TITLE
Fixed const_cast for non ESP8266

### DIFF
--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -1121,7 +1121,7 @@ public:
     // ESPAsyncTCP and RPAsyncTCP methods are not corrected declared with const for immutable ones.
     return static_cast<tcp_state>(const_cast<AsyncWebServer *>(this)->_server.status());
 #else
-    return static_cast<tcp_state>(_server.status());
+    return static_cast<tcp_state>(const_cast<AsyncWebServer *>(this)->_server.status());
 #endif
   }
 


### PR DESCRIPTION
There was a missing const_cast for non ESP8266 path of the ifdef.