### PR TITLE
Use const return value with strchr

### DIFF
--- a/src/AsyncWebHeader.cpp
+++ b/src/AsyncWebHeader.cpp
@@ -15,14 +15,14 @@ const AsyncWebHeader AsyncWebHeader::parse(const char *data) {
   if (strchr(data, '\n') || strchr(data, '\r')) {
     return AsyncWebHeader();  // Invalid header format
   }
-  char *colon = strchr(data, ':');
+  const char *colon = strchr(data, ':');
   if (!colon) {
     return AsyncWebHeader();  // separator not found
   }
   if (colon == data) {
     return AsyncWebHeader();  // Header name cannot be empty
   }
-  char *startOfValue = colon + 1;  // Skip the colon
+  const char *startOfValue = colon + 1;  // Skip the colon
   // skip one optional whitespace after the colon
   if (*startOfValue == ' ') {
     startOfValue++;


### PR DESCRIPTION
This patch makes the usage of strchr() return value slightly more strict by using const. This doesn't change any functionality but allows the code to be compiled in environments where we are forced to use C++ standard-compliant versions of strchr (that don't return char* when const char* is given).

This change also makes the code a bit safer and correct since the pointers in question are derived from a const char* data-parameter that was never meant for modification any way.