### PR TITLE
Remove unnecessary implementation of memchr

### DIFF
--- a/src/WebResponses.cpp
+++ b/src/WebResponses.cpp
@@ -6,17 +6,6 @@
 
 using namespace asyncsrv;
 
-// Since ESP8266 does not link memchr by default, here's its implementation.
-void *memchr(void *ptr, int ch, size_t count) {
-  unsigned char *p = static_cast<unsigned char *>(ptr);
-  while (count--) {
-    if (*p++ == static_cast<unsigned char>(ch)) {
-      return --p;
-    }
-  }
-  return nullptr;
-}
-
 /*
  * Abstract Response
  *


### PR DESCRIPTION
This patch removes an implementation of memchr() that seems unnecessary. The standard library even for ESP8266 provide this implementation in recent releases. Removal is preferred when source code is compiled with standard library that define the function as inline.