### PR TITLE
Fix ETag handling for dynamic template responses

### DIFF
--- a/examples/Templates/Templates.ino
+++ b/examples/Templates/Templates.ino
@@ -33,7 +33,7 @@ static const char *htmlContent PROGMEM = R"(
 
 static const size_t htmlContentLength = strlen_P(htmlContent);
 
-// Variables used for dynamic cachable template
+// Variables used for dynamic cacheable template
 static unsigned uptimeInMinutes = 0;
 static AsyncStaticWebHandler *uptimeHandler = nullptr;
 
@@ -102,7 +102,7 @@ void setup() {
       }
       return emptyString;
     })
-    .setLastModified("2025-01-01T01:02:03Z");  // Here I am using ISO 8601 timestamp format; this is not required
+    .setLastModified("Sun, 28 Sep 2025 01:02:03 GMT");
 
   // Serve a template with dynamic content *and* caching
   //

--- a/examples/Templates/Templates.ino
+++ b/examples/Templates/Templates.ino
@@ -35,13 +35,15 @@ static const size_t htmlContentLength = strlen_P(htmlContent);
 
 // Variables used for dynamic cachable template
 static unsigned uptimeInMinutes = 0;
-static AsyncStaticWebHandler* uptimeHandler = nullptr;
+static AsyncStaticWebHandler *uptimeHandler = nullptr;
 
 // Utility function for performing that update
 static void setUptimeInMinutes(unsigned t) {
-    uptimeInMinutes = t;
-    // Update caching header with a new value as well
-    if (uptimeHandler) uptimeHandler->setLastModified(static_cast<time_t>(t * 60));
+  uptimeInMinutes = t;
+  // Update caching header with a new value as well
+  if (uptimeHandler) {
+    uptimeHandler->setLastModified(static_cast<time_t>(t * 60));
+  }
 }
 
 void setup() {
@@ -77,8 +79,8 @@ void setup() {
   // serveStatic recognizes that template processing is in use, and will not automatically
   // add caching headers.
   //
-  // curl -v http://192.168.4.1/dynamic.html  
-  server.serveStatic("/dynamic.html", LittleFS,  "/template.html").setTemplateProcessor([](const String &var) -> String {
+  // curl -v http://192.168.4.1/dynamic.html
+  server.serveStatic("/dynamic.html", LittleFS, "/template.html").setTemplateProcessor([](const String &var) -> String {
     if (var == "USER") {
       return String("Bob ") + millis();
     }
@@ -93,12 +95,14 @@ void setup() {
   // Example below: USER never changes.
   //
   // curl -v http://192.168.4.1/index.html
-  server.serveStatic("/index.html", LittleFS, "/template.html").setTemplateProcessor([](const String &var) -> String {
-    if (var == "USER") {
-      return "Bob";
-    }
-    return emptyString;
-  }).setLastModified("2025-01-01T01:02:03Z"); // Here I am using ISO 8601 timestamp format; this is not required
+  server.serveStatic("/index.html", LittleFS, "/template.html")
+    .setTemplateProcessor([](const String &var) -> String {
+      if (var == "USER") {
+        return "Bob";
+      }
+      return emptyString;
+    })
+    .setLastModified("2025-01-01T01:02:03Z");  // Here I am using ISO 8601 timestamp format; this is not required
 
   // Serve a template with dynamic content *and* caching
   //
@@ -120,10 +124,10 @@ void setup() {
   // is used to generate the template callback.
   //
   // curl -v -G -d "USER=Bob" http://192.168.4.1/user_request.html
-  server.on("/user_request.html", HTTP_GET, [](AsyncWebServerRequest *request) {      
+  server.on("/user_request.html", HTTP_GET, [](AsyncWebServerRequest *request) {
     request->send(LittleFS, "/template.html", "text/html", false, [=](const String &var) -> String {
       if (var == "USER") {
-        const AsyncWebParameter* param = request->getParam("USER");
+        const AsyncWebParameter *param = request->getParam("USER");
         if (param) {
           return param->value();
         }
@@ -136,13 +140,13 @@ void setup() {
 }
 
 // not needed
-void loop() {  
+void loop() {
   delay(100);
 
   // Compute uptime
   unsigned currentUptimeInMinutes = millis() / (60 * 1000);
-  
+
   if (currentUptimeInMinutes != uptimeInMinutes) {
     setUptimeInMinutes(currentUptimeInMinutes);
-  }  
+  }
 }

--- a/examples/Templates/Templates.ino
+++ b/examples/Templates/Templates.ino
@@ -42,7 +42,7 @@ static void setUptimeInMinutes(unsigned t) {
   uptimeInMinutes = t;
   // Update caching header with a new value as well
   if (uptimeHandler) {
-    uptimeHandler->setLastModified(static_cast<time_t>(t * 60));
+    uptimeHandler->setLastModified();
   }
 }
 

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -204,6 +204,7 @@ class AsyncWebServerRequest {
   friend class AsyncWebServer;
   friend class AsyncCallbackWebHandler;
   friend class AsyncFileResponse;
+  friend class AsyncStaticWebHandler;
 
 private:
   AsyncClient *_client;

--- a/src/WebHandlers.cpp
+++ b/src/WebHandlers.cpp
@@ -190,9 +190,9 @@ bool AsyncStaticWebHandler::_searchFile(AsyncWebServerRequest *request, const St
 /**
  * @brief Handles an incoming HTTP request for a static file.
  *
- * This method processes a request for serving static files asynchronously.
- * It determines the correct ETag (entity tag) for caching, checks if the file
- * has been modified, and prepares the appropriate response (file response or 304 Not Modified).
+ * This method processes a request for serving static files asynchronously.  
+ * It determines the correct ETag (entity tag) for caching, checks if the file  
+ * has been modified, and prepares the appropriate response (file response or 304 Not Modified).  
  *
  * @param request Pointer to the incoming AsyncWebServerRequest object.
  */
@@ -207,11 +207,11 @@ void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest *request) {
     return;
   }
 
-  // Get server ETag. If file is not GZ and we have a Template Processor, ETag=0
+  // Get server ETag. If file is not GZ and we have a Template Processor, ETag=0 
   char etag[9];
-  const char *tempFileName = request->_tempFile.name();
+  const char* tempFileName = request->_tempFile.name();
   const size_t lenFilename = strlen(tempFileName);
-
+  
   if (lenFilename > T__GZ_LEN && memcmp(tempFileName + lenFilename - T__GZ_LEN, T__gz, T__GZ_LEN) == 0) {
     //File is a gz, get etag from CRC in trailer
     if (!AsyncWebServerRequest::_getEtag(request->_tempFile, etag)) {
@@ -221,9 +221,9 @@ void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest *request) {
       return;
     }
 
-    // Reset file position to the beginning after reading the gz trailer for ETag,
-    // so the file can be served from the start.
-    request->_tempFile.seek(0);
+  // Reset file position to the beginning after reading the gz trailer for ETag,
+  // so the file can be served from the start.
+  request->_tempFile.seek(0);
   } else if (_callback == nullptr) {
     // We don't have a Template processor
     uint32_t etagValue;
@@ -251,17 +251,23 @@ void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest *request) {
     response = new AsyncFileResponse(request->_tempFile, filename, emptyString, false, _callback);
 
     if (!response) {
-#ifdef ESP32
+  #ifdef ESP32
       log_e("Failed to allocate");
-#endif
+  #endif
       request->abort();
       return;
     }
     if (*etag != '\0') {
       response->addHeader(T_ETag, etag, true);
       response->addHeader(T_Cache_Control, T_no_cache, true);
-    } else if (_cache_control.length()) {
-      response->addHeader(T_Cache_Control, _cache_control.c_str(), false);
+    }
+    else {
+      if (_cache_control.length()) {
+        response->addHeader(T_Cache_Control, _cache_control.c_str(), false);
+      }
+      if (_last_modified.length()) {
+        response->addHeader(T_Last_Modified, _last_modified.c_str(), true);
+      }
     }
   }
   request->send(response);

--- a/src/WebHandlers.cpp
+++ b/src/WebHandlers.cpp
@@ -244,12 +244,12 @@ void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest *request) {
   bool notModified = false;
   // 1. If the client sent If-None-Match and we have an ETag → compare
   if (*etag != '\0' && request->header(T_INM) == etag) {
-      notModified = true;
+    notModified = true;
   }
   // 2. Otherwise, if there is no ETag but we have Last-Modified and Last-Modified matches
   else if (*etag == '\0' && _last_modified.length() > 0 && request->header(T_IMS) == _last_modified) {
     async_ws_log_d("_last_modified: %s", _last_modified.c_str());
-    notModified = true; 
+    notModified = true;
   }
 
   if (notModified) {

--- a/src/WebHandlers.cpp
+++ b/src/WebHandlers.cpp
@@ -190,9 +190,9 @@ bool AsyncStaticWebHandler::_searchFile(AsyncWebServerRequest *request, const St
 /**
  * @brief Handles an incoming HTTP request for a static file.
  *
- * This method processes a request for serving static files asynchronously.  
- * It determines the correct ETag (entity tag) for caching, checks if the file  
- * has been modified, and prepares the appropriate response (file response or 304 Not Modified).  
+ * This method processes a request for serving static files asynchronously.
+ * It determines the correct ETag (entity tag) for caching, checks if the file
+ * has been modified, and prepares the appropriate response (file response or 304 Not Modified).
  *
  * @param request Pointer to the incoming AsyncWebServerRequest object.
  */
@@ -207,11 +207,11 @@ void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest *request) {
     return;
   }
 
-  // Get server ETag. If file is not GZ and we have a Template Processor, ETag=0 
+  // Get server ETag. If file is not GZ and we have a Template Processor, ETag=0
   char etag[9];
-  const char* tempFileName = request->_tempFile.name();
+  const char *tempFileName = request->_tempFile.name();
   const size_t lenFilename = strlen(tempFileName);
-  
+
   if (lenFilename > T__GZ_LEN && memcmp(tempFileName + lenFilename - T__GZ_LEN, T__gz, T__GZ_LEN) == 0) {
     //File is a gz, get etag from CRC in trailer
     if (!AsyncWebServerRequest::_getEtag(request->_tempFile, etag)) {
@@ -221,9 +221,9 @@ void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest *request) {
       return;
     }
 
-  // Reset file position to the beginning after reading the gz trailer for ETag,
-  // so the file can be served from the start.
-  request->_tempFile.seek(0);
+    // Reset file position to the beginning after reading the gz trailer for ETag,
+    // so the file can be served from the start.
+    request->_tempFile.seek(0);
   } else if (_callback == nullptr) {
     // We don't have a Template processor
     uint32_t etagValue;
@@ -251,17 +251,16 @@ void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest *request) {
     response = new AsyncFileResponse(request->_tempFile, filename, emptyString, false, _callback);
 
     if (!response) {
-  #ifdef ESP32
+#ifdef ESP32
       log_e("Failed to allocate");
-  #endif
+#endif
       request->abort();
       return;
     }
     if (*etag != '\0') {
       response->addHeader(T_ETag, etag, true);
       response->addHeader(T_Cache_Control, T_no_cache, true);
-    }
-    else if (_cache_control.length()) {
+    } else if (_cache_control.length()) {
       response->addHeader(T_Cache_Control, _cache_control.c_str(), false);
     }
   }

--- a/src/WebHandlers.cpp
+++ b/src/WebHandlers.cpp
@@ -206,7 +206,7 @@ void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest *request) {
     return;
   }
 
-  // Get server ETag. If file is not GZ and we have a Template Processor, ETag=0
+  // Get server ETag. If file is not GZ and we have a Template Processor, ETag is set to an empty string
   char etag[9];
   const char *tempFileName = request->_tempFile.name();
   const size_t lenFilename = strlen(tempFileName);

--- a/src/WebHandlers.cpp
+++ b/src/WebHandlers.cpp
@@ -211,8 +211,8 @@ void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest *request) {
   char etag[9];
   const char* tempFileName = request->_tempFile.name();
   const size_t lenFilename = strlen(tempFileName);
-  const size_t gz_len = sizeof(T__gz) - 1;
-  if (lenFilename > sizeof(T__gz) && memcmp(tempFileName + lenFilename - gz_len, T__gz, gz_len) == 0) {
+  
+  if (lenFilename > T__GZ_LEN && memcmp(tempFileName + lenFilename - T__GZ_LEN, T__gz, T__GZ_LEN) == 0) {
     //File is a gz, get etag from CRC in trailer
     if (!AsyncWebServerRequest::_getEtag(request->_tempFile, etag)) {
       // File is corrupted or invalid
@@ -220,6 +220,7 @@ void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest *request) {
       request->send(404);
       return;
     }
+
   // Reset file position to the beginning after reading the gz trailer for ETag,
   // so the file can be served from the start.
   request->_tempFile.seek(0);
@@ -230,12 +231,8 @@ void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest *request) {
     if (lastWrite > 0) {
       // Use timestamp-based ETag
       etagValue = static_cast<uint32_t>(lastWrite);
-    } 
-    // Use filesize-based ETag
-    size_t fileSize = request->_tempFile.size();
-    etagValue = static_cast<uint32_t>(fileSize);
     } else {
-      // Use filesize-based ETag
+      // No timestamp available, use filesize-based ETag
       size_t fileSize = request->_tempFile.size();
       etagValue = static_cast<uint32_t>(fileSize);
     }

--- a/src/WebHandlers.cpp
+++ b/src/WebHandlers.cpp
@@ -257,12 +257,15 @@ void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest *request) {
     response = new AsyncBasicResponse(304);  // Not modified
   } else {
     response = new AsyncFileResponse(request->_tempFile, filename, emptyString, false, _callback);
-    if (!response) {
-      async_ws_log_e("Failed to allocate");
-      request->abort();
-      return;
-    }
+  }
 
+  if (!response) {
+    async_ws_log_e("Failed to allocate");
+    request->abort();
+    return;
+  }
+
+  if (!notModified) {
     // Set ETag header
     if (*etag != '\0') {
       response->addHeader(T_ETag, etag, true);

--- a/src/WebHandlers.cpp
+++ b/src/WebHandlers.cpp
@@ -190,9 +190,9 @@ bool AsyncStaticWebHandler::_searchFile(AsyncWebServerRequest *request, const St
 /**
  * @brief Handles an incoming HTTP request for a static file.
  *
- * This method processes a request for serving static files asynchronously.  
- * It determines the correct ETag (entity tag) for caching, checks if the file  
- * has been modified, and prepares the appropriate response (file response or 304 Not Modified).  
+ * This method processes a request for serving static files asynchronously.
+ * It determines the correct ETag (entity tag) for caching, checks if the file
+ * has been modified, and prepares the appropriate response (file response or 304 Not Modified).
  *
  * @param request Pointer to the incoming AsyncWebServerRequest object.
  */
@@ -207,11 +207,11 @@ void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest *request) {
     return;
   }
 
-  // Get server ETag. If file is not GZ and we have a Template Processor, ETag=0 
+  // Get server ETag. If file is not GZ and we have a Template Processor, ETag=0
   char etag[9];
-  const char* tempFileName = request->_tempFile.name();
+  const char *tempFileName = request->_tempFile.name();
   const size_t lenFilename = strlen(tempFileName);
-  
+
   if (lenFilename > T__GZ_LEN && memcmp(tempFileName + lenFilename - T__GZ_LEN, T__gz, T__GZ_LEN) == 0) {
     //File is a gz, get etag from CRC in trailer
     if (!AsyncWebServerRequest::_getEtag(request->_tempFile, etag)) {
@@ -221,8 +221,8 @@ void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest *request) {
       return;
     }
 
-  // Reset file position to the beginning so the file can be served from the start.
-  request->_tempFile.seek(0);
+    // Reset file position to the beginning so the file can be served from the start.
+    request->_tempFile.seek(0);
   } else if (_callback == nullptr) {
     // We don't have a Template processor
     uint32_t etagValue;
@@ -243,21 +243,21 @@ void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest *request) {
   AsyncWebServerResponse *response;
 
   // Get raw header pointers to avoid creating temporary String objects
-  const char* inm = request->header(T_INM).c_str();  // If-None-Match
-  const char* ims = request->header(T_IMS).c_str();  // If-Modified-Since
+  const char *inm = request->header(T_INM).c_str();  // If-None-Match
+  const char *ims = request->header(T_IMS).c_str();  // If-Modified-Since
 
   bool notModified = false;
   // 1. If the client sent If-None-Match and we have an ETag → compare
   if (*etag != '\0' && inm && *inm) {
-      if (strcmp(inm, etag) == 0) {
-          notModified = true;
-      }
+    if (strcmp(inm, etag) == 0) {
+      notModified = true;
+    }
   }
   // 2. Otherwise, if there is no ETag and no Template processor but we have Last-Modified and Last-Modified matches
   else if (*etag == '\0' && _callback == nullptr && _last_modified.length() > 0 && ims && *ims && strcmp(ims, _last_modified.c_str()) == 0) {
     log_d("_last_modified: %s", _last_modified.c_str());
     log_d("ims: %s", ims);
-    notModified = true; 
+    notModified = true;
   }
 
   if (notModified) {
@@ -266,9 +266,9 @@ void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest *request) {
   } else {
     response = new AsyncFileResponse(request->_tempFile, filename, emptyString, false, _callback);
     if (!response) {
-      #ifdef ESP32
-              log_e("Failed to allocate");
-      #endif
+#ifdef ESP32
+      log_e("Failed to allocate");
+#endif
       request->abort();
       return;
     }
@@ -286,8 +286,7 @@ void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest *request) {
   // Set cache control
   if (_cache_control.length()) {
     response->addHeader(T_Cache_Control, _cache_control.c_str(), false);
-  }
-  else {
+  } else {
     response->addHeader(T_Cache_Control, T_no_cache, false);
   }
 

--- a/src/WebHandlers.cpp
+++ b/src/WebHandlers.cpp
@@ -248,9 +248,9 @@ void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest *request) {
       notModified = true;
   }
   // 2. Otherwise, if there is no ETag but we have Last-Modified and Last-Modified matches
-  else if (*etag == '\0' && _callback == nullptr && _last_modified.length() > 0 && request->header(T_IMS) == _last_modified) {
+  else if (*etag == '\0' && _last_modified.length() > 0 && request->header(T_IMS) == _last_modified) {
     log_d("_last_modified: %s", _last_modified.c_str());
-    notModified = true;
+    notModified = true; 
   }
 
   if (notModified) {

--- a/src/WebHandlers.cpp
+++ b/src/WebHandlers.cpp
@@ -220,6 +220,8 @@ void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest *request) {
       request->send(404);
       return;
     }
+  // Reset file position to the beginning after reading the gz trailer for ETag,
+  // so the file can be served from the start.
   request->_tempFile.seek(0);
   } else if (_callback == nullptr) {
     // We don't have a Template processor

--- a/src/WebHandlers.cpp
+++ b/src/WebHandlers.cpp
@@ -232,7 +232,11 @@ void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest *request) {
     // Use filesize-based ETag
     size_t fileSize = request->_tempFile.size();
     etagValue = static_cast<uint32_t>(fileSize);
-    
+    } else {
+      // Use filesize-based ETag
+      size_t fileSize = request->_tempFile.size();
+      etagValue = static_cast<uint32_t>(fileSize);
+    }
     snprintf(etag, sizeof(etag), "%08x", etagValue);
   } else {
     etag[0] = '\0';

--- a/src/WebHandlers.cpp
+++ b/src/WebHandlers.cpp
@@ -242,21 +242,14 @@ void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest *request) {
 
   AsyncWebServerResponse *response;
 
-  // Get raw header pointers to avoid creating temporary String objects
-  const char *inm = request->header(T_INM).c_str();  // If-None-Match
-  const char *ims = request->header(T_IMS).c_str();  // If-Modified-Since
-
   bool notModified = false;
   // 1. If the client sent If-None-Match and we have an ETag → compare
-  if (*etag != '\0' && inm && *inm) {
-    if (strcmp(inm, etag) == 0) {
+  if (*etag != '\0' && request->header(T_INM) == etag) {
       notModified = true;
-    }
   }
-  // 2. Otherwise, if there is no ETag and no Template processor but we have Last-Modified and Last-Modified matches
-  else if (*etag == '\0' && _callback == nullptr && _last_modified.length() > 0 && ims && *ims && strcmp(ims, _last_modified.c_str()) == 0) {
+  // 2. Otherwise, if there is no ETag but we have Last-Modified and Last-Modified matches
+  else if (*etag == '\0' && _callback == nullptr && _last_modified.length() > 0 && request->header(T_IMS) == _last_modified) {
     log_d("_last_modified: %s", _last_modified.c_str());
-    log_d("ims: %s", ims);
     notModified = true;
   }
 

--- a/src/literals.h
+++ b/src/literals.h
@@ -115,6 +115,7 @@ static constexpr const char *T__jpg = ".jpg";      // JPEG/JPG: Photos. Legacy s
 static constexpr const char *T__js = ".js";        // JavaScript: Interactive functionality
 static constexpr const char *T__json = ".json";    // JSON: Data exchange format
 static constexpr const char *T__mp4 = ".mp4";      // MP4: Proprietary format. Worse compression than WEBM.
+static constexpr const char *T__mjs = ".mjs";      // MJS: JavaScript module format
 static constexpr const char *T__opus = ".opus";    // OPUS: High compression audio format
 static constexpr const char *T__pdf = ".pdf";      // PDF: Universal document format
 static constexpr const char *T__png = ".png";      // PNG: Icons, logos, transparency. Legacy support

--- a/src/literals.h
+++ b/src/literals.h
@@ -203,5 +203,5 @@ static constexpr const char *T_only_once_headers[] = {
   T_Transfer_Encoding, T_Content_Location, T_Server,       T_WWW_AUTH
 };
 static constexpr size_t T_only_once_headers_len = sizeof(T_only_once_headers) / sizeof(T_only_once_headers[0]);
-
+static constexpr size_t T__GZ_LEN = sizeof(T__gz) - 1;
 }  // namespace asyncsrv

--- a/src/literals.h
+++ b/src/literals.h
@@ -115,7 +115,6 @@ static constexpr const char *T__jpg = ".jpg";      // JPEG/JPG: Photos. Legacy s
 static constexpr const char *T__js = ".js";        // JavaScript: Interactive functionality
 static constexpr const char *T__json = ".json";    // JSON: Data exchange format
 static constexpr const char *T__mp4 = ".mp4";      // MP4: Proprietary format. Worse compression than WEBM.
-static constexpr const char *T__mjs = ".mjs";      // MJS: JavaScript module format
 static constexpr const char *T__opus = ".opus";    // OPUS: High compression audio format
 static constexpr const char *T__pdf = ".pdf";      // PDF: Universal document format
 static constexpr const char *T__png = ".png";      // PNG: Icons, logos, transparency. Legacy support
@@ -204,5 +203,5 @@ static constexpr const char *T_only_once_headers[] = {
   T_Transfer_Encoding, T_Content_Location, T_Server,       T_WWW_AUTH
 };
 static constexpr size_t T_only_once_headers_len = sizeof(T_only_once_headers) / sizeof(T_only_once_headers[0]);
-static constexpr size_t T__GZ_LEN = sizeof(T__gz) - 1;
+static constexpr size_t T__GZ_LEN = strlen(T__gz);
 }  // namespace asyncsrv


### PR DESCRIPTION
This PR updates AsyncStaticWebHandler::handleRequest to correctly manage caching headers when template processing introduces dynamic content. The previous implementation always set ETag and Last-Modified headers based on the underlying filesystem metadata, which was misleading when templates generated non-static responses (e.g., current time). Issue #237

The new implementation:
- Uses file-based ETag when .gz files or template callback is not present.
- Ensures gzip files generate consistent ETag values using _getEtag.
- For non-gzip files, generate ETag values ​​using the timestamp or file size.
- Returns 304 Not Modified only when If-None-Match matches the valid ETag.
- Removed use of Variable Length Array and String, ensuring the same implementation works consistently on all platforms.

This prevents browsers from incorrectly reusing cached content when template output is dynamic, ensuring correctness while still allowing efficient caching for static resources.