### PR TITLE
Improve JS MIME type detection

### DIFF
--- a/src/WebResponses.cpp
+++ b/src/WebResponses.cpp
@@ -639,8 +639,8 @@ void AsyncFileResponse::_setContentTypeFromPath(const String &path) {
     _contentType = T_text_html;
   } else if (strcmp(dot, T__css) == 0) {
     _contentType = T_text_css;
-  } else if (strcmp(dot, T__js) == 0) {
-    _contentType = T_application_javascript;
+  } else if (strcmp(dot, T__js) == 0 || strcmp(dot, T__mjs) == 0) {
+    _contentType = T_text_javascript;
   } else if (strcmp(dot, T__json) == 0) {
     _contentType = T_application_json;
   } else if (strcmp(dot, T__png) == 0) {

--- a/src/literals.h
+++ b/src/literals.h
@@ -115,6 +115,7 @@ static constexpr const char *T__jpg = ".jpg";      // JPEG/JPG: Photos. Legacy s
 static constexpr const char *T__js = ".js";        // JavaScript: Interactive functionality
 static constexpr const char *T__json = ".json";    // JSON: Data exchange format
 static constexpr const char *T__mp4 = ".mp4";      // MP4: Proprietary format. Worse compression than WEBM.
+static constexpr const char *T__mjs = ".mjs";      // MJS: JavaScript module format
 static constexpr const char *T__opus = ".opus";    // OPUS: High compression audio format
 static constexpr const char *T__pdf = ".pdf";      // PDF: Universal document format
 static constexpr const char *T__png = ".png";      // PNG: Icons, logos, transparency. Legacy support


### PR DESCRIPTION
Enhances the `_setContentTypeFromPath` method in `AsyncFileResponse` to better handle JavaScript MIME types.  

Previously, `.js` files were correctly recognized, but `.mjs` files (ES modules) were not and defaulted to `application/javascript`. This enhancement ensures both `.js` and `.mjs` files are assigned `text/javascript`, improving compatibility with modern browsers.  

All other MIME type handling remains unchanged. This change enhances robustness and standards compliance of the file server.

Fix the issue #267