### PR TITLE
Fix CORS behavior when credentials flag is set to true.

### DIFF
--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -891,7 +891,13 @@ public:
     _maxAge = seconds;
   }
 
-  void addCORSHeaders(AsyncWebServerResponse *response);
+#ifndef ESP8266
+  [[deprecated("Use instead: addCORSHeaders(AsyncWebServerRequest *request, AsyncWebServerResponse *response)")]]
+#endif
+  void addCORSHeaders(AsyncWebServerResponse *response) {
+    addCORSHeaders(nullptr, response);
+  }
+  void addCORSHeaders(AsyncWebServerRequest *request, AsyncWebServerResponse *response);
 
   void run(AsyncWebServerRequest *request, ArMiddlewareNext next);
 


### PR DESCRIPTION
When credential flag is set to true, origin cannot be set to * (browser contraint).

So we mimic the same behavior by answering back in `Access-Control-Allow-Origin` header the `Origin `value, but only if the user set origin to * in the CORS middleware settings.

Ref: https://github.com/ESP32Async/ESPAsyncWebServer/issues/294

Fix #294.