### PR TITLE
Fix compiler warning

### DIFF
--- a/src/WebHandlers.cpp
+++ b/src/WebHandlers.cpp
@@ -234,7 +234,11 @@ void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest *request) {
       size_t fileSize = request->_tempFile.size();
       etagValue = static_cast<uint32_t>(fileSize);
     }
+#ifndef ESP8266
+    snprintf(etag, sizeof(etag), "%08lx", etagValue);
+#else
     snprintf(etag, sizeof(etag), "%08x", etagValue);
+#endif
   } else {
     etag[0] = '\0';
   }


### PR DESCRIPTION
```
src/WebHandlers.cpp: In member function 'virtual void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest*)':
src/WebHandlers.cpp:237:38: warning: format '%x' expects argument of type 'unsigned int', but argument 4 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
  237 |     snprintf(etag, sizeof(etag), "%08x", etagValue);
      |                                   ~~~^   ~~~~~~~~~
      |                                      |   |
      |                                      |   uint32_t {aka long unsigned int}
      |                                      unsigned int
      |                                   %08lx
```