### PR TITLE
Introduce AsyncURIMatcher class to encapsulate the URI matching logic with and without regex support (-D ASYNCWEBSERVER_REGEX=1)

### DIFF
--- a/examples/URIMatcher/README.md
+++ b/examples/URIMatcher/README.md
@@ -1,0 +1,240 @@
+# AsyncURIMatcher Example
+
+This example demonstrates the comprehensive URI matching capabilities of the ESPAsyncWebServer library using the `AsyncURIMatcher` class.
+
+## Overview
+
+The `AsyncURIMatcher` class provides flexible and powerful URL routing mechanisms that go beyond simple string matching. It supports various matching strategies that can be combined to create sophisticated routing rules.
+
+**Important**: When using plain strings (not `AsyncURIMatcher` objects), the library uses auto-detection (`URIMatchAuto`) which analyzes the URI pattern and applies appropriate matching rules. This is **not** simple exact matching - it combines exact and folder matching by default!
+
+## Auto-Detection Behavior
+
+When you pass a plain string or `const char*` to `server.on()`, the `URIMatchAuto` flag is used, which:
+
+1. **Empty URI**: Matches everything
+2. **Ends with `*`**: Becomes prefix match (`URIMatchPrefix`)
+3. **Contains `/*.ext`**: Becomes extension match (`URIMatchExtension`)
+4. **Starts with `^` and ends with `$`**: Becomes regex match (if enabled)
+5. **Everything else**: Becomes **both** exact and folder match (`URIMatchPrefixFolder | URIMatchExact`)
+
+This means traditional string-based routes like `server.on("/path", handler)` will match:
+- `/path` (exact match)
+- `/path/anything` (folder match)
+
+But will **NOT** match `/path-suffix` (prefix without folder separator).
+
+## Features Demonstrated
+
+### 1. **Auto-Detection (Traditional Behavior)**
+- When using plain strings, automatically detects the appropriate matching strategy
+- Default behavior: combines exact and folder matching
+- Special patterns: `*` suffix → prefix, `/*.ext` → extension, regex patterns
+- Use cases: Traditional ESP32 web server behavior with enhanced capabilities
+- Examples: `/path` matches both `/path` and `/path/sub`
+
+### 2. **Exact Matching**
+- Matches only the exact URL specified
+- Use cases: API endpoints, specific pages
+- Examples: `/exact`, `/login`, `/dashboard`
+
+### 3. **Prefix Matching**
+- Matches URLs that start with the specified pattern
+- Use cases: API versioning, module grouping
+- Examples: `/api*` matches `/api/users`, `/api/posts`, etc.
+
+### 4. **Folder/Directory Matching**
+- Matches URLs under a specific directory path
+- Use cases: Admin sections, organized content
+- Examples: `/admin/` matches `/admin/users`, `/admin/settings`
+
+### 5. **Extension Matching**
+- Matches files with specific extensions under a path
+- Use cases: Static file serving, file type handlers
+- Examples: `/images/*.jpg` matches any `.jpg` file under `/images/`
+
+### 6. **Case Insensitive Matching**
+- Matches URLs regardless of character case
+- Use cases: User-friendly URLs, legacy support
+- Examples: `/CaSe` matches `/case`, `/CASE`, etc.
+
+### 7. **Regular Expression Matching**
+- Advanced pattern matching using regex (requires `ASYNCWEBSERVER_REGEX`)
+- Use cases: Complex URL patterns, parameter extraction
+- Examples: `/user/([0-9]+)` matches `/user/123` and captures the ID
+
+### 8. **Combined Flags**
+- Multiple matching strategies can be combined
+- Use cases: Flexible routing requirements
+- Examples: Case-insensitive prefix matching
+
+## Usage Patterns
+
+### Traditional String-based Routing (Auto-Detection)
+```cpp
+// Auto-detection with exact + folder matching
+server.on("/api", handler);          // Matches /api AND /api/anything
+server.on("/login", handler);        // Matches /login AND /login/sub
+
+// Auto-detection with prefix matching  
+server.on("/prefix*", handler);      // Matches /prefix, /prefix-test, /prefix/sub
+
+// Auto-detection with extension matching
+server.on("/images/*.jpg", handler); // Matches /images/pic.jpg, /images/sub/pic.jpg
+```
+
+### Explicit AsyncURIMatcher Syntax
+### Explicit AsyncURIMatcher Syntax
+```cpp
+// Exact matching only
+server.on(AsyncURIMatcher("/path", URIMatchExact), handler);
+
+// Prefix matching only
+server.on(AsyncURIMatcher("/api", URIMatchPrefix), handler);
+
+// Combined flags
+server.on(AsyncURIMatcher("/api", URIMatchPrefix | URIMatchCaseInsensitive), handler);
+```
+
+### Factory Functions
+```cpp
+// More readable and expressive
+server.on(AsyncURIMatcher::exact("/login"), handler);
+server.on(AsyncURIMatcher::prefix("/api"), handler);
+server.on(AsyncURIMatcher::dir("/admin"), handler);
+server.on(AsyncURIMatcher::ext("/images/*.jpg"), handler);
+server.on(AsyncURIMatcher::iExact("/case"), handler);
+
+#ifdef ASYNCWEBSERVER_REGEX
+server.on(AsyncURIMatcher::regex("^/user/([0-9]+)$"), handler);
+#endif
+```
+
+## Available Flags
+
+| Flag | Description |
+|------|-------------|
+| `URIMatchAuto` | Auto-detect match type from pattern (default) |
+| `URIMatchExact` | Exact URL match |
+| `URIMatchPrefix` | Prefix match |
+| `URIMatchPrefixFolder` | Folder prefix match (requires trailing /) |
+| `URIMatchExtension` | File extension match pattern |
+| `URIMatchCaseInsensitive` | Case insensitive matching |
+| `URIMatchRegex` | Regular expression matching (requires ASYNCWEBSERVER_REGEX) |
+
+## Testing the Example
+
+1. **Upload the sketch** to your ESP32/ESP8266
+2. **Connect to WiFi AP**: `esp-captive` (no password required)
+3. **Navigate to**: `http://192.168.4.1/`
+4. **Explore the examples** by clicking the organized test links
+5. **Monitor Serial output**: Open Serial Monitor to see detailed debugging information for each matched route
+
+### Test URLs Available (All Clickable from Homepage)
+
+**Auto-Detection Examples:**
+- `http://192.168.4.1/auto` (exact + folder match)
+- `http://192.168.4.1/auto/sub` (folder match - same handler!)
+- `http://192.168.4.1/wildcard-test` (auto-detected prefix)
+- `http://192.168.4.1/auto-images/photo.png` (auto-detected extension)
+
+**Factory Method Examples:**
+- `http://192.168.4.1/exact` (AsyncURIMatcher::exact)
+- `http://192.168.4.1/service/status` (AsyncURIMatcher::prefix)
+- `http://192.168.4.1/admin/users` (AsyncURIMatcher::dir)
+- `http://192.168.4.1/images/photo.jpg` (AsyncURIMatcher::ext)
+
+**Case Insensitive Examples:**
+- `http://192.168.4.1/case` (lowercase)
+- `http://192.168.4.1/CASE` (uppercase)
+- `http://192.168.4.1/CaSe` (mixed case)
+
+**Regex Examples (if ASYNCWEBSERVER_REGEX enabled):**
+- `http://192.168.4.1/user/123` (captures numeric ID)
+- `http://192.168.4.1/user/456` (captures numeric ID)
+
+**Combined Flags Examples:**
+- `http://192.168.4.1/mixedcase-test` (prefix + case insensitive)
+- `http://192.168.4.1/MIXEDCASE/sub` (prefix + case insensitive)
+
+### Console Output
+
+Each handler provides detailed debugging information via Serial output:
+```
+Auto-Detection Match (Traditional)
+Matched URL: /auto
+Uses auto-detection: exact + folder matching
+```
+
+```
+Factory Exact Match  
+Matched URL: /exact
+Uses AsyncURIMatcher::exact() factory function
+```
+
+```
+Regex Match - User ID
+Matched URL: /user/123
+Captured User ID: 123
+This regex matches /user/{number} pattern
+```
+
+## Compilation Options
+
+### Enable Regex Support
+To enable regular expression matching, compile with:
+```
+-D ASYNCWEBSERVER_REGEX
+```
+
+In PlatformIO, add to `platformio.ini`:
+```ini
+build_flags = -D ASYNCWEBSERVER_REGEX
+```
+
+In Arduino IDE, add to your sketch:
+```cpp
+#define ASYNCWEBSERVER_REGEX
+```
+
+## Performance Considerations
+
+1. **Exact matches** are fastest
+2. **Prefix matches** are very efficient  
+3. **Regex matches** are slower but most flexible
+4. **Case insensitive** matching adds minimal overhead
+5. **Auto-detection** adds slight parsing overhead at construction time
+
+## Real-World Applications
+
+### REST API Design
+```cpp
+// API versioning
+server.on(AsyncURIMatcher::prefix("/api/v1"), handleAPIv1);
+server.on(AsyncURIMatcher::prefix("/api/v2"), handleAPIv2);
+
+// Resource endpoints with IDs
+server.on(AsyncURIMatcher::regex("^/api/users/([0-9]+)$"), handleUserById);
+server.on(AsyncURIMatcher::regex("^/api/posts/([0-9]+)/comments$"), handlePostComments);
+```
+
+### File Serving
+```cpp
+// Serve different file types
+server.on(AsyncURIMatcher::ext("/assets/*.css"), serveCSSFiles);
+server.on(AsyncURIMatcher::ext("/assets/*.js"), serveJSFiles);
+server.on(AsyncURIMatcher::ext("/images/*.jpg"), serveImageFiles);
+```
+
+### Admin Interface
+```cpp
+// Admin section with authentication
+server.on(AsyncURIMatcher::dir("/admin"), handleAdminPages);
+server.on(AsyncURIMatcher::exact("/admin"), redirectToAdminDashboard);
+```
+
+## See Also
+
+- [ESPAsyncWebServer Documentation](https://github.com/ESP32Async/ESPAsyncWebServer)
+- [Regular Expression Reference](https://en.cppreference.com/w/cpp/regex)
+- Other examples in the `examples/` directory

--- a/examples/URIMatcher/URIMatcher.ino
+++ b/examples/URIMatcher/URIMatcher.ino
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright 2016-2025 Hristo Gochkov, Mathieu Carbou, Emil Muratov
+
+//
+// AsyncURIMatcher Examples - Advanced URI Matching and Routing
+//
+// This example demonstrates the various ways to use AsyncURIMatcher class
+// for flexible URL routing with different matching strategies:
+//
+// 1. Exact matching
+// 2. Prefix matching
+// 3. Folder/directory matching
+// 4. Extension matching
+// 5. Case insensitive matching
+// 6. Regex matching (if ASYNCWEBSERVER_REGEX is enabled)
+// 7. Factory functions for common patterns
+//
+// Test URLs:
+// - Exact: http://192.168.4.1/exact
+// - Prefix: http://192.168.4.1/prefix-anything
+// - Folder: http://192.168.4.1/api/users, http://192.168.4.1/api/posts
+// - Extension: http://192.168.4.1/images/photo.jpg, http://192.168.4.1/docs/readme.pdf
+// - Case insensitive: http://192.168.4.1/CaSe or http://192.168.4.1/case
+// - Wildcard: http://192.168.4.1/wildcard-test
+
+#include <Arduino.h>
+#if defined(ESP32) || defined(LIBRETINY)
+#include <AsyncTCP.h>
+#include <WiFi.h>
+#elif defined(ESP8266)
+#include <ESP8266WiFi.h>
+#include <ESPAsyncTCP.h>
+#elif defined(TARGET_RP2040) || defined(TARGET_RP2350) || defined(PICO_RP2040) || defined(PICO_RP2350)
+#include <RPAsyncTCP.h>
+#include <WiFi.h>
+#endif
+
+#include <ESPAsyncWebServer.h>
+
+static AsyncWebServer server(80);
+
+void setup() {
+  Serial.begin(115200);
+  Serial.println();
+  Serial.println("=== AsyncURIMatcher Example ===");
+
+#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+  WiFi.mode(WIFI_AP);
+  WiFi.softAP("esp-captive");
+  Serial.print("AP IP address: ");
+  Serial.println(WiFi.softAPIP());
+#endif
+
+  // =============================================================================
+  // 1. AUTO-DETECTION BEHAVIOR - traditional string-based routing
+  // =============================================================================
+
+  // Traditional string-based routing with auto-detection
+  // This uses URIMatchAuto which combines URIMatchPrefixFolder | URIMatchExact
+  // It will match BOTH "/auto" exactly AND "/auto/" + anything
+  server.on("/auto", HTTP_GET, [](AsyncWebServerRequest *request) {
+    Serial.println("Auto-Detection Match (Traditional)");
+    Serial.println("Matched URL: " + request->url());
+    Serial.println("Uses auto-detection: exact + folder matching");
+    request->send(200, "text/plain", "OK - Auto-detection match");
+  });
+
+  // Auto-detection for wildcard patterns (ends with *)
+  // This auto-detects as URIMatchPrefix
+  server.on("/wildcard*", HTTP_GET, [](AsyncWebServerRequest *request) {
+    Serial.println("Auto-Detected Wildcard (Prefix)");
+    Serial.println("Matched URL: " + request->url());
+    Serial.println("Auto-detected as prefix match due to trailing *");
+    request->send(200, "text/plain", "OK - Wildcard prefix match");
+  });
+
+  // Auto-detection for extension patterns (contains /*.ext)
+  // This auto-detects as URIMatchExtension
+  server.on("/auto-images/*.png", HTTP_GET, [](AsyncWebServerRequest *request) {
+    Serial.println("Auto-Detected Extension Pattern");
+    Serial.println("Matched URL: " + request->url());
+    Serial.println("Auto-detected as extension match due to /*.png pattern");
+    request->send(200, "text/plain", "OK - Extension match");
+  });
+
+  // =============================================================================
+  // 2. EXACT MATCHING - matches only the exact URL (explicit)
+  // =============================================================================
+
+  // Using factory function for exact match
+  server.on(AsyncURIMatcher::exact("/exact"), HTTP_GET, [](AsyncWebServerRequest *request) {
+    Serial.println("Factory Exact Match");
+    Serial.println("Matched URL: " + request->url());
+    Serial.println("Uses AsyncURIMatcher::exact() factory function");
+    request->send(200, "text/plain", "OK - Factory exact match");
+  });
+
+  // =============================================================================
+  // 3. PREFIX MATCHING - matches URLs that start with the pattern
+  // =============================================================================
+
+  // Using factory function for prefix match
+  server.on(AsyncURIMatcher::prefix("/service"), HTTP_GET, [](AsyncWebServerRequest *request) {
+    Serial.println("Service Prefix Match (Factory)");
+    Serial.println("Matched URL: " + request->url());
+    Serial.println("Uses AsyncURIMatcher::prefix() factory function");
+    request->send(200, "text/plain", "OK - Factory prefix match");
+  });
+
+  // =============================================================================
+  // 4. FOLDER/DIRECTORY MATCHING - matches URLs in a folder structure
+  // =============================================================================
+
+  // Folder match using factory function (automatically adds trailing slash)
+  server.on(AsyncURIMatcher::dir("/admin"), HTTP_GET, [](AsyncWebServerRequest *request) {
+    Serial.println("Admin Directory Match");
+    Serial.println("Matched URL: " + request->url());
+    Serial.println("This matches URLs under /admin/ directory");
+    Serial.println("Note: /admin (without slash) will NOT match");
+    request->send(200, "text/plain", "OK - Directory match");
+  });
+
+  // =============================================================================
+  // 5. EXTENSION MATCHING - matches files with specific extensions
+  // =============================================================================
+
+  // Image extension matching
+  server.on(AsyncURIMatcher::ext("/images/*.jpg"), HTTP_GET, [](AsyncWebServerRequest *request) {
+    Serial.println("JPG Image Handler");
+    Serial.println("Matched URL: " + request->url());
+    Serial.println("This matches any .jpg file under /images/");
+    request->send(200, "text/plain", "OK - Extension match");
+  });
+
+  // =============================================================================
+  // 6. CASE INSENSITIVE MATCHING
+  // =============================================================================
+
+  // Case insensitive exact match
+  server.on(AsyncURIMatcher::exact("/case", AsyncURIMatcher::CaseInsensitive), HTTP_GET, [](AsyncWebServerRequest *request) {
+    Serial.println("Case Insensitive Match");
+    Serial.println("Matched URL: " + request->url());
+    Serial.println("This matches /case in any case combination");
+    request->send(200, "text/plain", "OK - Case insensitive match");
+  });
+
+#ifdef ASYNCWEBSERVER_REGEX
+  // =============================================================================
+  // 7. REGEX MATCHING (only available if ASYNCWEBSERVER_REGEX is enabled)
+  // =============================================================================
+
+  // Regex match for numeric IDs
+  server.on(AsyncURIMatcher::regex("^/user/([0-9]+)$"), HTTP_GET, [](AsyncWebServerRequest *request) {
+    Serial.println("Regex Match - User ID");
+    Serial.println("Matched URL: " + request->url());
+    if (request->pathArg(0).length() > 0) {
+      Serial.println("Captured User ID: " + request->pathArg(0));
+    }
+    Serial.println("This regex matches /user/{number} pattern");
+    request->send(200, "text/plain", "OK - Regex match");
+  });
+#endif
+
+  // =============================================================================
+  // 8. COMBINED FLAGS EXAMPLE
+  // =============================================================================
+
+  // Combine multiple flags
+  server.on(AsyncURIMatcher::prefix("/MixedCase", AsyncURIMatcher::CaseInsensitive), HTTP_GET, [](AsyncWebServerRequest *request) {
+    Serial.println("Combined Flags Example");
+    Serial.println("Matched URL: " + request->url());
+    Serial.println("Uses both AsyncURIMatcher::Prefix and AsyncURIMatcher::CaseInsensitive");
+    request->send(200, "text/plain", "OK - Combined flags match");
+  });
+
+  // =============================================================================
+  // 9. HOMEPAGE WITH NAVIGATION
+  // =============================================================================
+
+  server.on("/", HTTP_GET, [](AsyncWebServerRequest *request) {
+    Serial.println("Homepage accessed");
+    String response = R"(<!DOCTYPE html>
+<html>
+<head>
+  <title>AsyncURIMatcher Examples</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    h1 { color: #2E86AB; }
+    .test-link { display: block; margin: 5px 0; padding: 8px; background: #f0f0f0; text-decoration: none; color: #333; border-radius: 4px; }
+    .test-link:hover { background: #e0e0e0; }
+    .section { margin: 20px 0; }
+  </style>
+</head>
+<body>
+  <h1>AsyncURIMatcher Examples</h1>
+
+  <div class="section">
+    <h3>Auto-Detection (Traditional String Matching)</h3>
+    <a href="/auto" class="test-link">/auto (auto-detection: exact + folder)</a>
+    <a href="/auto/sub" class="test-link">/auto/sub (folder match)</a>
+    <a href="/wildcard-test" class="test-link">/wildcard-test (auto prefix)</a>
+    <a href="/auto-images/photo.png" class="test-link">/auto-images/photo.png (auto extension)</a>
+  </div>
+
+  <div class="section">
+    <h3>Factory Method Examples</h3>
+    <a href="/exact" class="test-link">/exact (factory exact)</a>
+    <a href="/service/status" class="test-link">/service/status (factory prefix)</a>
+    <a href="/admin/users" class="test-link">/admin/users (factory directory)</a>
+    <a href="/images/photo.jpg" class="test-link">/images/photo.jpg (factory extension)</a>
+  </div>
+
+  <div class="section">
+    <h3>Case Insensitive Matching</h3>
+    <a href="/case" class="test-link">/case (lowercase)</a>
+    <a href="/CASE" class="test-link">/CASE (uppercase)</a>
+    <a href="/CaSe" class="test-link">/CaSe (mixed case)</a>
+  </div>
+
+)";
+#ifdef ASYNCWEBSERVER_REGEX
+    response += R"(  <div class="section">
+    <h3>Regex Matching</h3>
+    <a href="/user/123" class="test-link">/user/123 (regex numeric ID)</a>
+    <a href="/user/456" class="test-link">/user/456 (regex numeric ID)</a>
+  </div>
+
+)";
+#endif
+    response += R"(  <div class="section">
+    <h3>Combined Flags</h3>
+    <a href="/mixedcase-test" class="test-link">/mixedcase-test (prefix + case insensitive)</a>
+    <a href="/MIXEDCASE/sub" class="test-link">/MIXEDCASE/sub (prefix + case insensitive)</a>
+  </div>
+
+</body>
+</html>)";
+    request->send(200, "text/html", response);
+  });
+
+  // =============================================================================
+  // 10. NOT FOUND HANDLER
+  // =============================================================================
+
+  server.onNotFound([](AsyncWebServerRequest *request) {
+    String html = "<h1>404 - Not Found</h1>";
+    html += "<p>The requested URL <strong>" + request->url() + "</strong> was not found.</p>";
+    html += "<p><a href='/'>← Back to Examples</a></p>";
+    request->send(404, "text/html", html);
+  });
+
+  server.begin();
+
+  Serial.println();
+  Serial.println("=== Server Started ===");
+  Serial.println("Open your browser and navigate to:");
+  Serial.println("http://192.168.4.1/ - Main examples page");
+  Serial.println();
+  Serial.println("Available test endpoints:");
+  Serial.println("• Auto-detection: /auto (exact+folder), /wildcard*, /auto-images/*.png");
+  Serial.println("• Exact matches: /exact");
+  Serial.println("• Prefix matches: /service*");
+  Serial.println("• Folder matches: /admin/*");
+  Serial.println("• Extension matches: /images/*.jpg");
+  Serial.println("• Case insensitive: /case (try /CASE, /Case)");
+#ifdef ASYNCWEBSERVER_REGEX
+  Serial.println("• Regex matches: /user/123");
+#endif
+  Serial.println("• Combined flags: /mixedcase*");
+  Serial.println();
+}
+
+void loop() {
+  // Nothing to do here - the server handles everything asynchronously
+  delay(1000);
+}

--- a/examples/URIMatcherTest/URIMatcherTest.ino
+++ b/examples/URIMatcherTest/URIMatcherTest.ino
@@ -63,8 +63,56 @@ void setup() {
     request->send(200, "text/css", "/* OK */");
   });
 
+  // =============================================================================
+  // NEW ASYNCURIMATCHER FACTORY METHODS TESTS
+  // =============================================================================
+
+  // Exact match using factory method (does NOT match subpaths like traditional)
+  server.on(AsyncURIMatcher::exact("/factory/exact"), HTTP_GET, [](AsyncWebServerRequest *request) {
+    request->send(200, "text/plain", "OK");
+  });
+
+  // Prefix match using factory method
+  server.on(AsyncURIMatcher::prefix("/factory/prefix"), HTTP_GET, [](AsyncWebServerRequest *request) {
+    request->send(200, "text/plain", "OK");
+  });
+
+  // Directory match using factory method (matches /dir/anything but not /dir itself)
+  server.on(AsyncURIMatcher::dir("/factory/dir"), HTTP_GET, [](AsyncWebServerRequest *request) {
+    request->send(200, "text/plain", "OK");
+  });
+
+  // Extension match using factory method
+  server.on(AsyncURIMatcher::ext("/factory/files/*.txt"), HTTP_GET, [](AsyncWebServerRequest *request) {
+    request->send(200, "text/plain", "OK");
+  });
+
+  // =============================================================================
+  // CASE INSENSITIVE MATCHING TESTS
+  // =============================================================================
+
+  // Case insensitive exact match
+  server.on(AsyncURIMatcher::exact("/case/exact", AsyncURIMatcher::CaseInsensitive), HTTP_GET, [](AsyncWebServerRequest *request) {
+    request->send(200, "text/plain", "OK");
+  });
+
+  // Case insensitive prefix match
+  server.on(AsyncURIMatcher::prefix("/case/prefix", AsyncURIMatcher::CaseInsensitive), HTTP_GET, [](AsyncWebServerRequest *request) {
+    request->send(200, "text/plain", "OK");
+  });
+
+  // Case insensitive directory match
+  server.on(AsyncURIMatcher::dir("/case/dir", AsyncURIMatcher::CaseInsensitive), HTTP_GET, [](AsyncWebServerRequest *request) {
+    request->send(200, "text/plain", "OK");
+  });
+
+  // Case insensitive extension match
+  server.on(AsyncURIMatcher::ext("/case/files/*.PDF", AsyncURIMatcher::CaseInsensitive), HTTP_GET, [](AsyncWebServerRequest *request) {
+    request->send(200, "text/plain", "OK");
+  });
+
 #ifdef ASYNCWEBSERVER_REGEX
-  // Regex patterns
+  // Traditional regex patterns (backward compatibility)
   server.on("^/user/([0-9]+)$", HTTP_GET, [](AsyncWebServerRequest *request) {
     request->send(200, "text/plain", "OK");
   });
@@ -72,7 +120,35 @@ void setup() {
   server.on("^/blog/([0-9]{4})/([0-9]{2})/([0-9]{2})$", HTTP_GET, [](AsyncWebServerRequest *request) {
     request->send(200, "text/plain", "OK");
   });
+
+  // =============================================================================
+  // NEW ASYNCURIMATCHER REGEX FACTORY METHODS
+  // =============================================================================
+
+  // Regex match using factory method
+  server.on(AsyncURIMatcher::regex("^/factory/user/([0-9]+)$"), HTTP_GET, [](AsyncWebServerRequest *request) {
+    request->send(200, "text/plain", "OK");
+  });
+
+  // Case insensitive regex match using factory method
+  server.on(AsyncURIMatcher::regex("^/factory/search/(.+)$", AsyncURIMatcher::CaseInsensitive), HTTP_GET, [](AsyncWebServerRequest *request) {
+    request->send(200, "text/plain", "OK");
+  });
+
+  // Complex regex with multiple capture groups
+  server.on(AsyncURIMatcher::regex("^/factory/blog/([0-9]{4})/([0-9]{2})/([0-9]{2})$"), HTTP_GET, [](AsyncWebServerRequest *request) {
+    request->send(200, "text/plain", "OK");
+  });
 #endif
+
+  // =============================================================================
+  // SPECIAL MATCHERS
+  // =============================================================================
+
+  // Match all POST requests (catch-all before 404)
+  server.on(AsyncURIMatcher::all(), HTTP_POST, [](AsyncWebServerRequest *request) {
+    request->send(200, "text/plain", "OK");
+  });
 
   // 404 handler
   server.onNotFound([](AsyncWebServerRequest *request) {

--- a/examples/URIMatcherTest/test_routes.sh
+++ b/examples/URIMatcherTest/test_routes.sh
@@ -51,16 +51,89 @@ if test_route "/data/settings.json" "200" "JSON extension in subfolder"; then ((
 if test_route "/style.css" "200" "CSS extension"; then ((PASS++)); else ((FAIL++)); fi
 if test_route "/assets/main.css" "200" "CSS extension in subfolder"; then ((PASS++)); else ((FAIL++)); fi
 
+echo ""
+echo "Testing AsyncURIMatcher factory methods:"
+
+# Factory exact match (should NOT match subpaths)
+if test_route "/factory/exact" "200" "Factory exact match"; then ((PASS++)); else ((FAIL++)); fi
+
+# Factory prefix match
+if test_route "/factory/prefix" "200" "Factory prefix base"; then ((PASS++)); else ((FAIL++)); fi
+if test_route "/factory/prefix-test" "200" "Factory prefix extended"; then ((PASS++)); else ((FAIL++)); fi
+if test_route "/factory/prefix/sub" "200" "Factory prefix subpath"; then ((PASS++)); else ((FAIL++)); fi
+
+# Factory directory match (should NOT match the directory itself)
+if test_route "/factory/dir/users" "200" "Factory directory match"; then ((PASS++)); else ((FAIL++)); fi
+if test_route "/factory/dir/sub/path" "200" "Factory directory deep"; then ((PASS++)); else ((FAIL++)); fi
+
+# Factory extension match
+if test_route "/factory/files/doc.txt" "200" "Factory extension match"; then ((PASS++)); else ((FAIL++)); fi
+if test_route "/factory/files/sub/readme.txt" "200" "Factory extension deep"; then ((PASS++)); else ((FAIL++)); fi
+
+echo ""
+echo "Testing case insensitive matching:"
+
+# Case insensitive exact
+if test_route "/case/exact" "200" "Case exact lowercase"; then ((PASS++)); else ((FAIL++)); fi
+if test_route "/CASE/EXACT" "200" "Case exact uppercase"; then ((PASS++)); else ((FAIL++)); fi
+if test_route "/Case/Exact" "200" "Case exact mixed"; then ((PASS++)); else ((FAIL++)); fi
+
+# Case insensitive prefix
+if test_route "/case/prefix" "200" "Case prefix lowercase"; then ((PASS++)); else ((FAIL++)); fi
+if test_route "/CASE/PREFIX-test" "200" "Case prefix uppercase"; then ((PASS++)); else ((FAIL++)); fi
+if test_route "/Case/Prefix/sub" "200" "Case prefix mixed"; then ((PASS++)); else ((FAIL++)); fi
+
+# Case insensitive directory
+if test_route "/case/dir/users" "200" "Case dir lowercase"; then ((PASS++)); else ((FAIL++)); fi
+if test_route "/CASE/DIR/admin" "200" "Case dir uppercase"; then ((PASS++)); else ((FAIL++)); fi
+if test_route "/Case/Dir/settings" "200" "Case dir mixed"; then ((PASS++)); else ((FAIL++)); fi
+
+# Case insensitive extension
+if test_route "/case/files/doc.pdf" "200" "Case ext lowercase"; then ((PASS++)); else ((FAIL++)); fi
+if test_route "/CASE/FILES/DOC.PDF" "200" "Case ext uppercase"; then ((PASS++)); else ((FAIL++)); fi
+if test_route "/Case/Files/Doc.Pdf" "200" "Case ext mixed"; then ((PASS++)); else ((FAIL++)); fi
+
+echo ""
+echo "Testing special matchers:"
+
+# Test POST to catch-all (all() matcher)
+echo -n "Testing POST /any/path (all matcher) ... "
+response=$(curl -s -X POST -w "HTTPSTATUS:%{http_code}" "$BASE_URL/any/path" 2>/dev/null)
+status_code=$(echo "$response" | grep -o "HTTPSTATUS:[0-9]*" | cut -d: -f2)
+if [ "$status_code" = "200" ]; then
+    echo "✅ PASS ($status_code)"
+    ((PASS++))
+else
+    echo "❌ FAIL (expected 200, got $status_code)"
+    ((FAIL++))
+fi
+
 # Check if regex is enabled by testing the server
 echo ""
 echo "Checking for regex support..."
 regex_test=$(curl -s "$BASE_URL/user/123" 2>/dev/null)
 if curl -s -w "%{http_code}" "$BASE_URL/user/123" 2>/dev/null | grep -q "200"; then
-    echo "Regex support detected - testing regex routes:"
-    if test_route "/user/123" "200" "Regex user ID"; then ((PASS++)); else ((FAIL++)); fi
-    if test_route "/user/456" "200" "Regex user ID 2"; then ((PASS++)); else ((FAIL++)); fi
-    if test_route "/blog/2023/10/15" "200" "Regex blog date"; then ((PASS++)); else ((FAIL++)); fi
-    if test_route "/blog/2024/12/25" "200" "Regex blog date 2"; then ((PASS++)); else ((FAIL++)); fi
+    echo "Regex support detected - testing traditional regex routes:"
+    if test_route "/user/123" "200" "Traditional regex user ID"; then ((PASS++)); else ((FAIL++)); fi
+    if test_route "/user/456" "200" "Traditional regex user ID 2"; then ((PASS++)); else ((FAIL++)); fi
+    if test_route "/blog/2023/10/15" "200" "Traditional regex blog date"; then ((PASS++)); else ((FAIL++)); fi
+    if test_route "/blog/2024/12/25" "200" "Traditional regex blog date 2"; then ((PASS++)); else ((FAIL++)); fi
+
+    echo "Testing AsyncURIMatcher regex factory methods:"
+    if test_route "/factory/user/123" "200" "Factory regex user ID"; then ((PASS++)); else ((FAIL++)); fi
+    if test_route "/factory/user/789" "200" "Factory regex user ID 2"; then ((PASS++)); else ((FAIL++)); fi
+    if test_route "/factory/blog/2023/10/15" "200" "Factory regex blog date"; then ((PASS++)); else ((FAIL++)); fi
+    if test_route "/factory/blog/2024/12/31" "200" "Factory regex blog date 2"; then ((PASS++)); else ((FAIL++)); fi
+
+    # Case insensitive regex
+    if test_route "/factory/search/hello" "200" "Factory regex search lowercase"; then ((PASS++)); else ((FAIL++)); fi
+    if test_route "/FACTORY/SEARCH/WORLD" "200" "Factory regex search uppercase"; then ((PASS++)); else ((FAIL++)); fi
+    if test_route "/Factory/Search/Test" "200" "Factory regex search mixed"; then ((PASS++)); else ((FAIL++)); fi
+
+    # Test regex validation
+    if test_route "/user/abc" "404" "Invalid regex (letters instead of numbers)"; then ((PASS++)); else ((FAIL++)); fi
+    if test_route "/blog/23/10/15" "404" "Invalid regex (2-digit year)"; then ((PASS++)); else ((FAIL++)); fi
+    if test_route "/factory/user/abc" "404" "Factory regex invalid (letters)"; then ((PASS++)); else ((FAIL++)); fi
 else
     echo "Regex support not detected (compile with ASYNCWEBSERVER_REGEX to enable)"
 fi
@@ -69,9 +142,19 @@ echo ""
 echo "Testing routes that should fail (404 Not Found):"
 
 if test_route "/nonexistent" "404" "Non-existent route"; then ((PASS++)); else ((FAIL++)); fi
-if test_route "/exact-sub" "404" "Exact path with extra characters"; then ((PASS++)); else ((FAIL++)); fi
-if test_route "/user/abc" "404" "Invalid regex (letters instead of numbers)"; then ((PASS++)); else ((FAIL++)); fi
-if test_route "/blog/23/10/15" "404" "Invalid regex (2-digit year)"; then ((PASS++)); else ((FAIL++)); fi
+
+# Test factory exact vs traditional behavior difference
+if test_route "/factory/exact/sub" "404" "Factory exact should NOT match subpaths"; then ((PASS++)); else ((FAIL++)); fi
+
+# Test factory directory requires trailing slash
+if test_route "/factory/dir" "404" "Factory directory should NOT match without trailing slash"; then ((PASS++)); else ((FAIL++)); fi
+
+# Test extension mismatch
+if test_route "/factory/files/doc.pdf" "404" "Factory extension mismatch (.pdf vs .txt)"; then ((PASS++)); else ((FAIL++)); fi
+
+# Test case sensitive when flag not used
+if test_route "/exact" "200" "Traditional exact lowercase"; then ((PASS++)); else ((FAIL++)); fi
+if test_route "/EXACT" "404" "Traditional exact should be case sensitive"; then ((PASS++)); else ((FAIL++)); fi
 
 echo ""
 echo "=================================="

--- a/platformio.ini
+++ b/platformio.ini
@@ -33,6 +33,7 @@ src_dir = examples/PerfTests
 ; src_dir = examples/StaticFile
 ; src_dir = examples/Templates
 ; src_dir = examples/Upload
+; src_dir = examples/URIMatcher
 ; src_dir = examples/URIMatcherTest
 ; src_dir = examples/WebSocket
 ; src_dir = examples/WebSocketEasy

--- a/src/AsyncJson.cpp
+++ b/src/AsyncJson.cpp
@@ -112,11 +112,12 @@ size_t AsyncMessagePackResponse::_fillBuffer(uint8_t *data, size_t len) {
 // Body handler supporting both content types: JSON and MessagePack
 
 #if ARDUINOJSON_VERSION_MAJOR == 6
-AsyncCallbackJsonWebHandler::AsyncCallbackJsonWebHandler(const String &uri, ArJsonRequestHandlerFunction onRequest, size_t maxJsonBufferSize)
-  : _uri(uri), _method(HTTP_GET | HTTP_POST | HTTP_PUT | HTTP_PATCH), _onRequest(onRequest), maxJsonBufferSize(maxJsonBufferSize), _maxContentLength(16384) {}
+AsyncCallbackJsonWebHandler::AsyncCallbackJsonWebHandler(AsyncURIMatcher uri, ArJsonRequestHandlerFunction onRequest, size_t maxJsonBufferSize)
+  : _uri(std::move(uri)), _method(HTTP_GET | HTTP_POST | HTTP_PUT | HTTP_PATCH), _onRequest(onRequest), maxJsonBufferSize(maxJsonBufferSize),
+    _maxContentLength(16384) {}
 #else
-AsyncCallbackJsonWebHandler::AsyncCallbackJsonWebHandler(const String &uri, ArJsonRequestHandlerFunction onRequest)
-  : _uri(uri), _method(HTTP_GET | HTTP_POST | HTTP_PUT | HTTP_PATCH), _onRequest(onRequest), _maxContentLength(16384) {}
+AsyncCallbackJsonWebHandler::AsyncCallbackJsonWebHandler(AsyncURIMatcher uri, ArJsonRequestHandlerFunction onRequest)
+  : _uri(std::move(uri)), _method(HTTP_GET | HTTP_POST | HTTP_PUT | HTTP_PATCH), _onRequest(onRequest), _maxContentLength(16384) {}
 #endif
 
 bool AsyncCallbackJsonWebHandler::canHandle(AsyncWebServerRequest *request) const {
@@ -124,7 +125,7 @@ bool AsyncCallbackJsonWebHandler::canHandle(AsyncWebServerRequest *request) cons
     return false;
   }
 
-  if (_uri.length() && (_uri != request->url() && !request->url().startsWith(_uri + "/"))) {
+  if (!_uri.matches(request)) {
     return false;
   }
 

--- a/src/AsyncJson.h
+++ b/src/AsyncJson.h
@@ -88,7 +88,7 @@ public:
 
 class AsyncCallbackJsonWebHandler : public AsyncWebHandler {
 protected:
-  String _uri;
+  AsyncURIMatcher _uri;
   WebRequestMethodComposite _method;
   ArJsonRequestHandlerFunction _onRequest;
 #if ARDUINOJSON_VERSION_MAJOR == 6
@@ -98,9 +98,9 @@ protected:
 
 public:
 #if ARDUINOJSON_VERSION_MAJOR == 6
-  AsyncCallbackJsonWebHandler(const String &uri, ArJsonRequestHandlerFunction onRequest = nullptr, size_t maxJsonBufferSize = DYNAMIC_JSON_DOCUMENT_SIZE);
+  AsyncCallbackJsonWebHandler(AsyncURIMatcher uri, ArJsonRequestHandlerFunction onRequest = nullptr, size_t maxJsonBufferSize = DYNAMIC_JSON_DOCUMENT_SIZE);
 #else
-  AsyncCallbackJsonWebHandler(const String &uri, ArJsonRequestHandlerFunction onRequest = nullptr);
+  AsyncCallbackJsonWebHandler(AsyncURIMatcher uri, ArJsonRequestHandlerFunction onRequest = nullptr);
 #endif
 
   void setMethod(WebRequestMethodComposite method) {

--- a/src/WebHandlerImpl.h
+++ b/src/WebHandlerImpl.h
@@ -54,7 +54,7 @@ public:
 class AsyncCallbackWebHandler : public AsyncWebHandler {
 private:
 protected:
-  String _uri;
+  AsyncURIMatcher _uri;
   WebRequestMethodComposite _method;
   ArRequestHandlerFunction _onRequest;
   ArUploadHandlerFunction _onUpload;
@@ -63,7 +63,7 @@ protected:
 
 public:
   AsyncCallbackWebHandler() : _uri(), _method(HTTP_ANY), _onRequest(NULL), _onUpload(NULL), _onBody(NULL), _isRegex(false) {}
-  void setUri(const String &uri);
+  void setUri(AsyncURIMatcher uri);
   void setMethod(WebRequestMethodComposite method) {
     _method = method;
   }

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -151,10 +151,10 @@ void AsyncWebServer::_attachHandler(AsyncWebServerRequest *request) {
 }
 
 AsyncCallbackWebHandler &AsyncWebServer::on(
-  const char *uri, WebRequestMethodComposite method, ArRequestHandlerFunction onRequest, ArUploadHandlerFunction onUpload, ArBodyHandlerFunction onBody
+  AsyncURIMatcher uri, WebRequestMethodComposite method, ArRequestHandlerFunction onRequest, ArUploadHandlerFunction onUpload, ArBodyHandlerFunction onBody
 ) {
   AsyncCallbackWebHandler *handler = new AsyncCallbackWebHandler();
-  handler->setUri(uri);
+  handler->setUri(std::move(uri));
   handler->setMethod(method);
   handler->onRequest(onRequest);
   handler->onUpload(onUpload);
@@ -164,8 +164,8 @@ AsyncCallbackWebHandler &AsyncWebServer::on(
 }
 
 #if ASYNC_JSON_SUPPORT == 1
-AsyncCallbackJsonWebHandler &AsyncWebServer::on(const char *uri, WebRequestMethodComposite method, ArJsonRequestHandlerFunction onBody) {
-  AsyncCallbackJsonWebHandler *handler = new AsyncCallbackJsonWebHandler(uri, onBody);
+AsyncCallbackJsonWebHandler &AsyncWebServer::on(AsyncURIMatcher uri, WebRequestMethodComposite method, ArJsonRequestHandlerFunction onBody) {
+  AsyncCallbackJsonWebHandler *handler = new AsyncCallbackJsonWebHandler(std::move(uri), onBody);
   handler->setMethod(method);
   addHandler(handler);
   return *handler;
@@ -201,4 +201,142 @@ void AsyncWebServer::reset() {
   _catchAllHandler->onRequest(NULL);
   _catchAllHandler->onUpload(NULL);
   _catchAllHandler->onBody(NULL);
+}
+
+AsyncURIMatcher::AsyncURIMatcher(String uri, uint16_t modifiers) : _value(std::move(uri)) {
+#ifdef ASYNCWEBSERVER_REGEX
+  if (_value.startsWith("^") && _value.endsWith("$")) {
+    pattern = new std::regex(_value.c_str(), (modifiers & CaseInsensitive) ? (std::regex::icase | std::regex::optimize) : (std::regex::optimize));
+    return;  // no additional processing - flags are overwritten by pattern pointer
+  }
+#endif
+  if (modifiers & CaseInsensitive) {
+    _value.toLowerCase();
+  }
+  // Inspect _value to set flags
+  // empty URI matches everything
+  if (!_value.length()) {
+    _flags = _toFlags(Type::All, modifiers);
+  } else if (_value.endsWith("*")) {
+    // wildcard match with * at the end
+    _flags = _toFlags(Type::Prefix, modifiers);
+    _value = _value.substring(0, _value.length() - 1);
+  } else if (_value.lastIndexOf("/*.") >= 0) {
+    // prefix match with /*.ext
+    // matches any path ending with .ext
+    // e.g. /images/*.png will match /images/pic.png and /images/2023/pic.png but not /img/pic.png
+    _flags = _toFlags(Type::Extension, modifiers);
+  } else {
+    // backward compatible use case: exact match or prefix with trailing /
+    _flags = _toFlags(Type::BackwardCompatible, modifiers);
+  }
+}
+
+AsyncURIMatcher::AsyncURIMatcher(String uri, Type type, uint16_t modifiers) : _value(std::move(uri)), _flags(_toFlags(type, modifiers)) {
+#ifdef ASYNCWEBSERVER_REGEX
+  if (type == Type::Regex) {
+    pattern = new std::regex(_value.c_str(), (modifiers & CaseInsensitive) ? (std::regex::icase | std::regex::optimize) : (std::regex::optimize));
+    return;  // no additional processing - flags are overwritten by pattern pointer
+  }
+#endif
+  if (modifiers & CaseInsensitive) {
+    _value.toLowerCase();
+  }
+}
+
+#ifdef ASYNCWEBSERVER_REGEX
+
+AsyncURIMatcher::AsyncURIMatcher(const AsyncURIMatcher &c) : _value(c._value), _flags(c._flags) {
+  if (_isRegex()) {
+    pattern = new std::regex(*pattern);
+  }
+}
+
+AsyncURIMatcher::AsyncURIMatcher(AsyncURIMatcher &&c) : _value(std::move(c._value)), _flags(c._flags) {
+  c._flags = _toFlags(Type::None, None);
+}
+
+AsyncURIMatcher::~AsyncURIMatcher() {
+  if (_isRegex()) {
+    delete pattern;
+  }
+}
+
+AsyncURIMatcher &AsyncURIMatcher::operator=(const AsyncURIMatcher &r) {
+  _value = r._value;
+  if (r._isRegex()) {
+    // Allocate first before we delete our current state
+    auto p = new std::regex(*r.pattern);
+    // Safely reassign our pattern
+    if (_isRegex()) {
+      delete pattern;
+    }
+    pattern = p;
+  } else {
+    if (_isRegex()) {
+      delete pattern;
+    }
+    _flags = r._flags;
+  }
+  return *this;
+}
+
+AsyncURIMatcher &AsyncURIMatcher::operator=(AsyncURIMatcher &&r) {
+  _value = std::move(r._value);
+  if (_isRegex()) {
+    delete pattern;
+  }
+  _flags = r._flags;
+  if (r._isRegex()) {
+    // We have adopted it
+    r._flags = _toFlags(Type::None, None);
+  }
+  return *this;
+}
+
+#endif
+
+bool AsyncURIMatcher::matches(AsyncWebServerRequest *request) const {
+#ifdef ASYNCWEBSERVER_REGEX
+  if (_isRegex()) {
+    // when type == Type::Regex, or when _value was auto-detected as regex
+    std::smatch matches;
+    std::string s(request->url().c_str());
+    if (std::regex_search(s, matches, *pattern)) {
+      for (size_t i = 1; i < matches.size(); ++i) {
+        request->_pathParams.emplace_back(matches[i].str().c_str());
+      }
+      return true;
+    }
+    return false;
+  }
+#endif
+
+  // extract matcher type from _flags
+  Type type;
+  uint16_t modifiers;
+  std::tie(type, modifiers) = _fromFlags(_flags);
+
+  // apply modifiers
+  String path = request->url();
+  if (modifiers & CaseInsensitive) {
+    path.toLowerCase();
+  }
+
+  switch (type) {
+    case Type::All:    return true;
+    case Type::None:   return false;
+    case Type::Exact:  return (_value == path);
+    case Type::Prefix: return path.startsWith(_value);
+    case Type::Extension:
+    {
+      int split = _value.lastIndexOf("/*.");
+      return (split >= 0 && path.startsWith(_value.substring(0, split)) && path.endsWith(_value.substring(split + 2)));
+    }
+    case Type::BackwardCompatible: return (_value == path) || path.startsWith(_value + "/");
+    default:
+      // Should never happen - programming error
+      assert("Invalid type");
+      return false;
+  }
 }


### PR DESCRIPTION
This PR wil replace https://github.com/ESP32Async/ESPAsyncWebServer/pull/299

This pull request introduces two new example sketches and a comprehensive README for demonstrating and testing the advanced URI matching capabilities of the ESPAsyncWebServer library, specifically focusing on the `AsyncURIMatcher` class. The changes provide both a user-friendly demonstration (`URIMatcher.ino`) and a thorough test suite (`URIMatcherTest.ino`) covering all matching strategies, including factory methods, case-insensitive matching, and regex support. The new documentation in `README.md` explains matching behavior, usage patterns, and real-world applications.

**New Example and Test Sketches**

* Added `examples/URIMatcher/URIMatcher.ino`: A demonstration sketch showcasing all matching strategies supported by `AsyncURIMatcher`, including exact, prefix, folder, extension, case-insensitive, regex, and combined flag matching. Includes a navigable HTML homepage and detailed Serial output for each route.
* Added `examples/URIMatcherTest/URIMatcherTest.ino`: A test suite for validating all matching modes, including factory methods, case-insensitive matching, regex, and catch-all routes. Designed for automated testing with external scripts.

**Documentation and Usage Guide**

* Added `examples/URIMatcher/README.md`: A comprehensive guide explaining the `AsyncURIMatcher` class, auto-detection logic, matching strategies, usage patterns, available flags, performance notes, and real-world application examples.

**Demonstration Features**

* Demonstrates traditional string-based routing (auto-detection), explicit matcher syntax, factory functions, and combined flags for flexible routing. [[1]](diffhunk://#diff-ff074527b6092bb4fa7538d951d0b655ca7b9f08cd52633d713747e6ce6188a0R1-R276) [[2]](diffhunk://#diff-d25f39b84cd954cd0a05de2e9a9e5a91b65cae95d796e6b94d8cef79fe88ee64R1-R240)
* Shows how to enable and use regular expression matching via the `ASYNCWEBSERVER_REGEX` compilation flag. [[1]](diffhunk://#diff-ff074527b6092bb4fa7538d951d0b655ca7b9f08cd52633d713747e6ce6188a0R1-R276) [[2]](diffhunk://#diff-d25f39b84cd954cd0a05de2e9a9e5a91b65cae95d796e6b94d8cef79fe88ee64R1-R240)

**Testing Enhancements**

* The test sketch includes coverage for all matcher types, case-insensitive variants, regex patterns, and a catch-all POST handler, ensuring robust validation of the URI matching subsystem.

**References:** [[1]](diffhunk://#diff-ff074527b6092bb4fa7538d951d0b655ca7b9f08cd52633d713747e6ce6188a0R1-R276) [[2]](diffhunk://#diff-1ddff96205765731b4601ee5b0f4be98264ce1055d82dd8f77442ced9b773114R1-R165) [[3]](diffhunk://#diff-d25f39b84cd954cd0a05de2e9a9e5a91b65cae95d796e6b94d8cef79fe88ee64R1-R240)