### PR TITLE
Reimplementing WebSockets

### DIFF
--- a/src/AsyncWSocket.cpp
+++ b/src/AsyncWSocket.cpp
@@ -3,6 +3,8 @@
 
 // A new experimental implementation of Async WebSockets client/server
 
+// We target C++17 capable toolchain
+#if __cplusplus >= 201703L
 #include "AsyncWSocket.h"
 #include "literals.h"
 
@@ -939,3 +941,4 @@ void WSocketServerWorker::_taskRunner(){
   vTaskDelete(NULL);
 }
 
+#endif  // __cplusplus >= 201703L

--- a/src/AsyncWSocket.cpp
+++ b/src/AsyncWSocket.cpp
@@ -1,0 +1,741 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright 2016-2025 Hristo Gochkov, Mathieu Carbou, Emil Muratov
+
+// A new experimental implementation of Async WebSockets client/server
+
+#include "AsyncWSocket.h"
+#include "literals.h"
+
+constexpr const char WS_STR_CONNECTION[] = "Connection";
+//constexpr const char WS_STR_UPGRADE[] = "Upgrade";
+//constexpr const char WS_STR_ORIGIN[] = "Origin";
+//constexpr const char WS_STR_COOKIE[] = "Cookie";
+constexpr const char WS_STR_VERSION[] = "Sec-WebSocket-Version";
+constexpr const char WS_STR_KEY[] = "Sec-WebSocket-Key";
+constexpr const char WS_STR_PROTOCOL[] = "Sec-WebSocket-Protocol";
+//constexpr const char WS_STR_ACCEPT[] = "Sec-WebSocket-Accept";
+
+
+/**
+ * @brief apply mask key to supplied data byte-per-byte
+ * this is used for unaligned portions of data buffer where 32 bit ops can't be applied
+ * this function takes mask offset to rollover the key bytes
+ *
+ * @param mask - mask key
+ * @param mask_offset - offset byte for mask
+ * @param data - data to apply
+ * @param length - data block length
+ */
+inline void wsMaskPayloadPerByte(uint32_t mask, size_t mask_offset, char *data, size_t length) {
+    for (char* ptr = data; ptr != data + length; ++ptr) {
+      *ptr ^= reinterpret_cast<uint8_t*>(&mask)[mask_offset++];  // roll mask bytes
+      if (mask_offset == sizeof(mask))
+        mask_offset = 0;
+    }
+  }
+  
+/**
+ * @brief apply mask key to supplied data using 32 bit XOR
+ * 
+ * @param mask - mask key
+ * @param mask_offset - offset byte for mask
+ * @param data - data to apply
+ * @param length - data block length
+ */
+void wsMaskPayload(uint32_t mask, size_t mask_offset, char *data, size_t length) {
+  /*
+    we could benefit from 32-bit xor to unmask the data. The great thing of esp32 is that it could do unaligned 32 bit memory access
+    while some other MCU does not (yes, RP2040, I'm talking about you!) So have to go hard way - do all operations 32-bit aligned to cover all supported MCUs
+  */
+
+  // If data size is so small that it does not make sense to use 32 bit aligned calculations, just use byte-by-byte version
+  if (length < 4 * sizeof(mask)){
+    wsMaskPayloadPerByte(mask, mask_offset % 4, data, length);
+  } else {
+    // do 32-bit vectored calculations
+
+    // get unaligned part size
+    const size_t head_remainder = reinterpret_cast<size_t>(data) % sizeof(mask);
+    // set aligned head
+    char* data_aligned_head = head_remainder == 0 ? data : (data + sizeof(mask) - head_remainder);
+    // set aligned tail
+    char* const data_end = data + length;
+    char* const data_aligned_end = data_end - reinterpret_cast<size_t>(data_end) % sizeof(mask);
+
+    // unmask unaligned part at the begining
+    if (head_remainder)
+      wsMaskPayloadPerByte(mask, mask_offset % 4, data, head_remainder);
+
+    // need a derived mask key in a 32 bit var which is rolled over by the appropriate offset for data position, our byte-by-byte function could help here to derive key
+    uint32_t shifted_mask{0};
+    wsMaskPayloadPerByte(mask, (mask_offset + data_aligned_head - data) % sizeof(mask), reinterpret_cast<char*>(&shifted_mask), sizeof(mask));
+
+    // (un)mask the payload
+    do {
+      *reinterpret_cast<uint32_t*>(data_aligned_head) ^= shifted_mask;
+      data_aligned_head += sizeof(mask);
+    } while(data_aligned_head != data_aligned_end);
+
+    // unmask the unalined remainder
+    wsMaskPayloadPerByte(mask, (mask_offset + (data_aligned_end - data)) % sizeof(mask), data_aligned_end, data_end - data_aligned_end);
+  }
+}
+
+size_t webSocketSendHeader(AsyncClient *client, WSMessageFrame& frame) {
+  if (!client || !client->canSend()) {
+    return 0;
+  }
+
+  size_t headLen = 2;
+  if (frame.len > 65535){
+    headLen += 8;
+  } else if (frame.len > 125) {
+    headLen += 2;
+  }
+  if (frame.len && frame.mask) {
+    headLen += 4;
+  }
+
+  size_t space = client->space();
+  if (space < headLen) {
+    // Serial.println("SF 2");
+    return 0;
+  }
+  space -= headLen;
+
+  // header buffer
+  uint8_t buf[headLen];
+
+  buf[0] = static_cast<uint8_t>(frame.msg->type) & 0x0F;
+  if (frame.msg->final()) {
+    buf[0] |= 0x80;
+  }
+  if (frame.len < 126) {
+    // 1 byte len
+    buf[1] = frame.len & 0x7F;
+  } else if (frame.len > 65535){
+    // 8 byte len
+    buf[1] = 127;
+    uint32_t lenl = htonl(frame.len & 0xffffffff);
+    uint32_t lenh = htonl(frame.len >> 32);
+    memcpy(buf+2, &lenh, sizeof(lenh));
+    memcpy(buf+6, &lenl, sizeof(lenl));
+  } else {
+    // 2 byte len
+    buf[1] = 126;
+    *(uint16_t*)(buf+2) = htons(frame.len & 0xffff);
+  }
+
+  if (frame.len && frame.mask) {
+    buf[1] |= 0x80;
+    memcpy(buf + (headLen - sizeof(frame.mask)), &frame.mask, sizeof(frame.mask));
+  }
+
+  size_t sent = client->add((const char*)buf, headLen);
+
+  if (frame.msg->type == WSFrameType_t::close && frame.msg->getStatusCode()){
+    // this is a 'close' message with status code, need to send the code also along with header
+    uint16_t code = htons (frame.msg->getStatusCode());
+    sent += client->add((char*)(&code), 2);
+    headLen += 2;
+  }
+
+  // return size of a header added or 0 if any error
+  return sent == headLen ? sent : 0;
+}
+
+
+// ******** WSocket classes implementation ********
+
+WSocketClient::WSocketClient(uint32_t id, AsyncWebServerRequest *request, WSocketClient::event_callback_t call_back, size_t msgsize, size_t qcapsize) : 
+  id(id),
+  _client(request->client()),
+  _cb(call_back),
+  _max_msgsize(msgsize),
+  _max_qcap(qcapsize)
+{
+  // disable connection timeout
+  _client->setRxTimeout(0);
+  _client->setNoDelay(true);
+  // set AsyncTCP callbacks
+  _client->onAck( [](void *r, AsyncClient *c, size_t len, uint32_t rtt) { (void)c; reinterpret_cast<WSocketClient*>(r)->_clientSend(len); }, this );
+  //_client->onAck( [](void *r, AsyncClient *c, size_t len, uint32_t rtt) { (void)c; reinterpret_cast<WSocketClient*>(r)->_onAck(len, rtt); }, this );
+  _client->onDisconnect( [](void *r, AsyncClient *c) { reinterpret_cast<WSocketClient*>(r)->_onDisconnect(c); }, this );
+  _client->onTimeout( [](void *r, AsyncClient *c, uint32_t time) { (void)c; reinterpret_cast<WSocketClient*>(r)->_onTimeout(time); }, this );
+  _client->onData( [](void *r, AsyncClient *c, void *buf, size_t len) { (void)c; reinterpret_cast<WSocketClient*>(r)->_onData(buf, len); }, this );
+  _client->onPoll( [](void *r, AsyncClient *c) { (void)c; reinterpret_cast<WSocketClient*>(r)->_clientSend(); }, this );
+  // not implemented yet
+  //_client->onError( [](void *r, AsyncClient *c, int8_t error) { (void)c; reinterpret_cast<WSocketClient*>(r)->_onError(error); }, this );
+  delete request;
+}
+
+WSocketClient::~WSocketClient() {
+  if (_client){
+    delete _client;
+    _client = nullptr;
+  }
+}
+
+// ***** AsyncTCP callbacks *****
+//#ifdef NOTHING
+// callback acknowledges sending pieces of data for outgoing frame
+void WSocketClient::_clientSend(size_t acked_bytes){
+  if (!_client || _connection == conn_state_t::disconnected || !_client->space())
+    return;
+
+  /*
+    this method could be called from different threads - AsyncTCP's ack/poll and user thread when enqueing messages,
+    only AsyncTCP's ack is mandatory to execute since it carries acked data size, others could be ignored completely
+    if this call is already exucute in progress. Worse case it will catch up later on next poll
+  */
+
+  // create lock object but don't actually take the lock yet
+  std::unique_lock lock{_sendLock, std::defer_lock};
+
+  if (acked_bytes){
+    // if it's the ack call from AsyncTCP - wait for lock!
+    lock.lock();
+    log_d("_clientSend, ack:%u/%u, space:%u", acked_bytes, _in_flight, _client ? _client->space() : 0);
+  } else {
+    // if there is no acked data - just quit, we are already sending something
+    if (!lock.try_lock())
+      return;
+  }
+
+  // for response data we need to control AsyncTCP's event queue and in-flight fragmentation. Sending small chunks could give lower latency,
+  // but flood asynctcp's queue and fragment socket buffer space for large responses.
+  // Let's ignore polled acks and acks in case when we have more in-flight data then the available socket buff space.
+  // That way we could balance on having half the buffer in-flight while another half is filling up and minimizing events in asynctcp's Q
+  if (acked_bytes){
+    _in_flight -= std::min(acked_bytes, _in_flight);
+    log_d("infl:%u, state:%u", _in_flight, _connection);
+    // check if we were waiting to ack our disconnection frame
+    if (!_in_flight && (_connection == conn_state_t::disconnecting)){
+      log_d("closing tcp-conn");
+      // we are server, should close connection first as per https://datatracker.ietf.org/doc/html/rfc6455#section-7.1.1
+      // here we close from the app side, send TCP-FIN to the party and move to FIN_WAIT_1/2 states
+      _client->close();
+      return;
+    }
+    
+    // return buffer credit on acked data
+    ++_in_flight_credit;
+  }
+
+  if (_in_flight > _client->space() || !_in_flight_credit) {
+    log_d("defer ws send call, in-flight:%u/%u", _in_flight, _client->space());
+    return;
+  }
+
+  // no message in transit, try to evict one from a Q
+  if (!_outFrame.msg){
+    if (_evictOutQueue()){
+      // generate header and add to the socket buffer
+      _in_flight += webSocketSendHeader(_client, _outFrame);
+    } else
+      return; // nothing to send now
+  }
+  
+  // if there is a pending _outFrame - send the data from there
+  while (_outFrame.msg){
+    if (_outFrame.index < _outFrame.len){
+      size_t payload_pend = _client->add(_outFrame.msg->getCurrentChunk().first + _outFrame.chunk_offset, _outFrame.msg->getCurrentChunk().second - _outFrame.chunk_offset);
+      // if no data was added to client's buffer then it's something wrong, we can't go on
+      if (!payload_pend){
+        _client->abort();
+        return;
+      }
+      _outFrame.index += payload_pend;
+      _outFrame.chunk_offset += payload_pend;
+      _in_flight += payload_pend;
+    }
+
+    if (_outFrame.index == _outFrame.len){
+      // if we complete writing entire message, send the frame right away
+      // increment in-flight counter and take the credit
+      if (!_client->send())
+        _client->abort();
+      --_in_flight_credit;
+
+      if (_outFrame.msg->type == WSFrameType_t::close){
+        // if we just sent close frame, then change client state and purge out queue, we won't transmit anything from now on
+        // the connection will be terminated once all in-flight data are acked from the other side
+        _connection = conn_state_t::disconnecting;
+        _outFrame.msg.reset();
+        _messageQueueOut.clear();
+        return;
+      }
+
+      // release _outFrame message here
+      _outFrame.msg.reset();
+
+      // execute callback that a message was sent
+      if (_cb)
+      _cb(this, event_t::msgSent);
+    
+      // if there are free in-flight credits try to pull next msg from Q
+      if (_in_flight_credit && _evictOutQueue()){
+        // generate header and add to the socket buffer
+        _in_flight += webSocketSendHeader(_client, _outFrame);
+        continue;
+      } else {
+        return;
+      }
+    }
+
+    if (!_client->space()){
+      // we have exhausted socket buffer, send it and quit
+      if (!_client->send())
+        _client->abort();
+      // take in-flight credit
+      --_in_flight_credit;
+      return;
+    }
+
+    // othewise it was chunked message object and current chunk has been complete
+    if (_outFrame.chunk_offset == _outFrame.msg->getCurrentChunk().second){
+      // request a new one
+      size_t next_chunk_size = _outFrame.msg->getNextChunk();
+      if (next_chunk_size == 0){
+        // chunk is not ready yet, need to async wait and return for data later, we quit here and reevaluate on next ack or poll event from AsyncTCP
+        if (!_client->send()) _client->abort();
+        // take in-flight credit
+        --_in_flight_credit;
+        return;
+      } else if (next_chunk_size == -1){
+        // something is wrong! there would be no more chunked data but the message has not reached it's full size yet, can do nothing but close the coonections
+        log_e("Chunk data is incomlete!");
+        _client->abort();
+        return;
+      }
+      // go on with a loop
+    } else {
+      // can't be there?
+    }
+  }
+}
+
+bool WSocketClient::_evictOutQueue(){
+  // check if we have something in the Q and enough sock space to send a header at least
+  if (_messageQueueOut.size() && _client->space() > 16 ){
+    {
+      #ifdef ESP32
+      std::unique_lock<std::recursive_mutex> lockout(_outQlock);
+      #endif
+      _outFrame.msg.swap(_messageQueueOut.front());
+      _messageQueueOut.pop_front();
+    }
+    _outFrame.chunk_offset = _outFrame.index = 0;
+    _outFrame.len = _outFrame.msg->getSize();
+    return true;
+  }
+
+  return false;
+  // this function assumes it's callee will take care of actually sending the header and message body further
+}
+
+void WSocketClient::_onError(int8_t) {
+  // Serial.println("onErr");
+}
+
+void WSocketClient::_onTimeout(uint32_t time) {
+  if (!_client) {
+    return;
+  }
+  // Serial.println("onTime");
+  (void)time;
+  _client->abort();
+}
+
+void WSocketClient::_onDisconnect(AsyncClient *c) {
+  Serial.println("TCP client disconencted");
+  delete c;
+  _client = c = nullptr;
+  _connection = conn_state_t::disconnected;
+
+  #ifdef ESP32
+  std::lock_guard<std::recursive_mutex> lock(_outQlock);
+  #endif
+  // clear out Q, we won't be able to send it anyway from now on
+  _messageQueueOut.clear();
+  // execute callback
+  if (_cb)
+    _cb(this, event_t::disconnect);
+}
+
+void WSocketClient::_onData(void *pbuf, size_t plen) {
+  Serial.printf("_onData, len:%u\n", plen);
+  if (!pbuf || !plen || _connection == conn_state_t::disconnected) return;
+  char *data = (char *)pbuf;
+
+  while (plen){
+    if (!_inFrame.msg){
+      // it's a new frame, need to parse header data
+      size_t framelen;
+      uint16_t errcode;
+      std::tie(framelen, errcode) = _mkNewFrame(data, plen, _inFrame);
+      if (!framelen){
+        // was unable to start receiving frame? initiate disconnect exchange
+        #ifdef ESP32
+        std::unique_lock<std::recursive_mutex> lockout(_outQlock);
+        #endif
+        _messageQueueOut.push_front( std::make_shared<WSMessageClose>(errcode) );
+        // try sending disconnect message now
+        _clientSend();
+        return;
+      }
+      // receiving a new frame from here
+      data += framelen;
+      plen -= framelen;
+    } else {
+      // continuation of existing frame
+      size_t payload_len = std::min(static_cast<size_t>(_inFrame.len - _inFrame.index), plen);
+      // unmask the payload
+      if (_inFrame.mask)
+        wsMaskPayload(_inFrame.mask, _inFrame.index, static_cast<char*>(data), payload_len);
+
+      // todo: for now assume object will consume all the payload provided
+      _inFrame.msg->addChunk(data, payload_len, _inFrame.index);
+      data += payload_len;
+      plen -= payload_len;
+    }
+  
+    // if we got whole frame now
+    if (_inFrame.index == _inFrame.len){
+      Serial.printf("_onData, cmplt msg len:%lu\n", _inFrame.len);
+
+      switch (_inFrame.msg->type){
+        // received close message
+        case WSFrameType_t::close : {
+          if (_connection == conn_state_t::disconnecting){
+            log_d("recv close ack");
+            // if it was ws-close ack - we can close TCP connection
+            _connection == conn_state_t::disconnected;
+            // normally we should call close() here and wait for other side also close tcp connection with TCP-FIN, but
+            // for various reasons ws clients could linger connection when received TCP-FIN not closing it from the app side (even after
+            // two side ws-close exchange, i.e. websocat, websocket-client)
+            // This would make server side TCP to stay in FIN_WAIT_2 state quite long time, let's call abort() here instead of close(),
+            // it is harsh but let other side know that nobody would talk to it any longer and let it reinstate a new connection if needed
+            // anyway we won't receive/send anything due to '_connection == conn_state_t::disconnected;'
+            _client->abort();
+            _inFrame.msg.reset();
+            return;
+          }
+          
+          // otherwise it's a close request from a peer - echo back close message as per https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.1
+          {
+            log_d("recv client's ws-close req");
+            #ifdef ESP32
+            std::unique_lock<std::recursive_mutex> lockin(_inQlock);
+            std::unique_lock<std::recursive_mutex> lockout(_outQlock);
+            #endif
+            // push message to recv Q, client might use it to understand disconnection reason
+            _messageQueueIn.push_back(_inFrame.msg);
+            // purge the out Q and echo recieved frame back to client, once it's tcp-acked from the other side we can close tcp connection
+            _messageQueueOut.clear();
+            _messageQueueOut.push_front(_inFrame.msg);
+          }
+          _inFrame.msg.reset();
+          if (_cb)
+            _cb(this, event_t::msgRecv);
+
+          break;
+        }
+
+        case WSFrameType_t::ping : {
+          #ifdef ESP32
+            std::unique_lock<std::recursive_mutex> lock(_outQlock);
+          #endif
+          // just reply to ping, does user needs this ping message?
+          _messageQueueOut.emplace_front( std::make_shared<WSMessageContainer<std::string>>(WSFrameType_t::pong, true, _inFrame.msg->getData()) );
+          _inFrame.msg.reset();
+          break;
+        }
+
+        default: {
+          log_e("other msg");
+          // any other messages
+          {
+            #ifdef ESP32
+            std::unique_lock<std::recursive_mutex> lock(_inQlock);
+            #endif
+            // check in-queue for overflow
+            if (_messageQueueIn.size() >= _max_qcap){
+              log_e("q overflow");
+              switch (_overflow_policy){
+                case overflow_t::discard :
+                  // discard incoming message
+                  break;
+                case overflow_t::drophead :
+                  _messageQueueIn.pop_front();
+                  _messageQueueIn.push_back(_inFrame.msg);
+                  break;
+                case overflow_t::droptail :
+                  _messageQueueIn.pop_back();
+                  _messageQueueIn.push_back(_inFrame.msg);
+                  break;
+                case overflow_t::disconnect : {
+                  #ifdef ESP32
+                  std::unique_lock<std::recursive_mutex> lock(_inQlock);
+                  #endif
+                  _messageQueueOut.push_front( std::make_shared<WSMessageClose>(1011, "Server Q overflow") );
+                  break;
+                }
+                default:;
+              }
+
+            } else {
+              log_e("push new to Q");
+              _messageQueueIn.push_back(_inFrame.msg);
+            }
+          }
+          _inFrame.msg.reset();
+          log_e("evt on new msg");
+          if (_cb)
+            _cb(this, event_t::msgRecv);
+
+          break;
+        }
+      }
+    }
+  }
+
+}
+
+std::pair<size_t, uint16_t> WSocketClient::_mkNewFrame(char* data, size_t len, WSMessageFrame& frame){
+  if (len < 2) return {0, 1002};    // return protocol error
+  uint8_t opcode = data[0] & 0x0F;
+  bool final = data[0] & 0x80;
+  bool masked = data[1] & 0x80;
+
+  // read frame size
+  frame.len = data[1] & 0x7F;
+  size_t offset = 2;  // first 2 bytes
+
+  if (frame.len == 126 && len >= 4) {
+    frame.len = data[3] | (uint16_t)(data[2]) << 8;
+    offset += 2;
+  } else if (frame.len == 127 && len >= 10) {
+    frame.len = ntohl(*(uint32_t*)(data + 2));  // MSB
+    frame.len <= 32;
+    frame.len |= ntohl(*(uint32_t*)(data + 6)); // LSB
+    offset += 8;
+  }
+
+  if (frame.len > _max_msgsize)   // message too big than we allowed to accept
+    return {0, 1009};
+
+  // if ws.close() is called, Safari sends a close frame with plen 2 and masked bit set. We must not try to read mask key from beyond packet size
+  if (masked && len >= offset + 4) {
+    // mask bytes order are LSB, so we can copy it as-is
+    frame.mask = *reinterpret_cast<uint32_t*>(data + offset);
+    Serial.printf("mask key at %u, :0x", offset);
+    Serial.println(frame.mask, HEX);
+    offset += 4;
+  }
+
+  frame.index = frame.chunk_offset = 0;
+
+  size_t bodylen = std::min(static_cast<size_t>(frame.len), len - offset);
+  // if there is no body in message, then it must a specific control message with no payload
+  if (!bodylen){
+    // I'll make an empty binary container for such messages
+    _inFrame.msg = std::make_shared<WSMessageContainer<std::vector<uint8_t>>>(static_cast<WSFrameType_t>(opcode));
+  } else {
+    // let's unmask payload right in sock buff, later it could be consumed as raw data
+    if (masked){
+      wsMaskPayload(_inFrame.mask, 0, data + offset, bodylen);
+    }
+
+    // create a new container object that fits best for message type
+    switch (static_cast<WSFrameType_t>(opcode)){
+      case WSFrameType_t::text :
+        // create a text message container consuming as much data as possible from current payload
+        _inFrame.msg = std::make_shared<WSMessageContainer<std::string>>(WSFrameType_t::text, final, (char*)(data + offset), bodylen);
+        break;
+
+      case WSFrameType_t::close : {
+        uint16_t status_code = ntohs(*(uint16_t*)(data + offset));
+        offset += 2;
+        if (bodylen > 2){
+          bodylen -= 2;
+          // create a text message container consuming as much data as possible from current payload
+          _inFrame.msg = std::make_shared<WSMessageClose>(status_code, data + offset, bodylen);
+        } else {
+          // must be close message w/o body
+          _inFrame.msg = std::make_shared<WSMessageClose>(status_code);
+        }
+        break;
+      }
+
+      default:
+        _inFrame.msg = std::make_shared<WSMessageContainer<std::vector<uint8_t>>>(static_cast<WSFrameType_t>(opcode), bodylen);
+        // copy data
+        memcpy(_inFrame.msg->getData(), data + offset, bodylen);
+
+    }
+    offset += bodylen;
+    _inFrame.index = bodylen;
+  }
+
+  log_e("new msg offset:%u, body:%u", offset, bodylen);
+  // return the number of consumed data from input buffer
+  return {offset, 0};
+}
+
+WSocketClient::err_t WSocketClient::enqueueMessage(std::shared_ptr<WSMessageGeneric> mptr){
+  if (_connection != conn_state_t::connected)
+    return err_t::disconnected;
+
+  if (_messageQueueOut.size() < _max_qcap){
+    #ifdef ESP32
+    std::lock_guard<std::recursive_mutex> lock(_outQlock);
+    #endif
+    _messageQueueOut.emplace_back( std::move(mptr) );
+    _clientSend();
+    return err_t::ok;
+  }
+
+  return err_t::nospace;
+}
+
+std::shared_ptr<WSMessageGeneric> WSocketClient::dequeueMessage(){
+  #ifdef ESP32
+  std::unique_lock<std::recursive_mutex> lock(_inQlock);
+  #endif
+  std::shared_ptr<WSMessageGeneric> msg;
+  if (_messageQueueIn.size()){
+    msg.swap(_messageQueueIn.front());
+    _messageQueueIn.pop_front();
+  }
+  return msg;
+}
+
+WSocketClient::err_t WSocketClient::canSend() const {
+  if (_connection != conn_state_t::connected) return err_t::disconnected;
+  if (_messageQueueOut.size() >= _max_qcap ) return err_t::nospace;
+  return err_t::ok;
+}
+
+WSocketClient::err_t WSocketClient::close(uint16_t code, const char *message){
+  if (_connection != conn_state_t::connected)
+    return err_t::disconnected;
+
+  #ifdef ESP32
+  std::lock_guard<std::recursive_mutex> lock(_outQlock);
+  #endif
+  if (message)
+    _messageQueueOut.emplace_front( std::make_shared<WSMessageClose>(code, message) );
+  else
+    _messageQueueOut.emplace_front( std::make_shared<WSMessageClose>(code) );
+  _clientSend();
+  return err_t::ok;
+}
+
+// ***** WSocketServer implementation *****
+
+
+bool WSocketServer::newClient(AsyncWebServerRequest *request){
+  // remove expired clients first
+  _purgeClients();
+  {
+    #ifdef ESP32
+    std::lock_guard<std::mutex> lock (_lock);
+    #endif
+    _clients.emplace_back(getNextId(), request, [this](WSocketClient *c, WSocketClient::event_t e){ _clientEvents(c, e); });
+  }
+  _clientEvents(&_clients.back(), WSocketClient::event_t::connect);
+  return true;
+}
+
+void WSocketServer::_clientEvents(WSocketClient *client, WSocketClient::event_t event){
+  log_d("_clientEvents: %u", event);
+  if (_eventHandler)
+    _eventHandler(client, event);
+}
+
+void WSocketServer::handleRequest(AsyncWebServerRequest *request) {
+  if (!request->hasHeader(WS_STR_VERSION) || !request->hasHeader(WS_STR_KEY)) {
+    request->send(400);
+    return;
+  }
+  if (_handshakeHandler != nullptr) {
+    if (!_handshakeHandler(request)) {
+      request->send(401);
+      return;
+    }
+  }
+  const AsyncWebHeader *version = request->getHeader(WS_STR_VERSION);
+  if (version->value().compareTo(asyncsrv::T_13) != 0) {
+    AsyncWebServerResponse *response = request->beginResponse(400);
+    response->addHeader(WS_STR_VERSION, asyncsrv::T_13);
+    request->send(response);
+    return;
+  }
+  const AsyncWebHeader *key = request->getHeader(WS_STR_KEY);
+  AsyncWebServerResponse *response = new AsyncWebSocketResponse(key->value(), [this](AsyncWebServerRequest *r){ return newClient(r); });
+  if (response == NULL) {
+#ifdef ESP32
+    log_e("Failed to allocate");
+#endif
+    request->abort();
+    return;
+  }
+  if (request->hasHeader(WS_STR_PROTOCOL)) {
+    const AsyncWebHeader *protocol = request->getHeader(WS_STR_PROTOCOL);
+    // ToDo: check protocol
+    response->addHeader(WS_STR_PROTOCOL, protocol->value());
+  }
+  request->send(response);
+}
+
+WSocketClient* WSocketServer::_getClient(uint32_t id) {
+  auto iter = std::find_if(_clients.begin(), _clients.end(), [id](const WSocketClient &c) { return c.id == id; });
+  if (iter != std::end(_clients))
+    return &(*iter);
+  else
+    return nullptr;
+}
+
+WSocketClient const* WSocketServer::_getClient(uint32_t id) const {
+  const auto iter = std::find_if(_clients.cbegin(), _clients.cend(), [id](const WSocketClient &c) { return c.id == id; });
+  if (iter != std::cend(_clients))
+    return &(*iter);
+  else
+    return nullptr;
+}
+
+WSocketServer::msgall_err_t WSocketServer::canSend() const {
+  size_t cnt = std::count_if(std::begin(_clients), std::end(_clients), [](const WSocketClient &c) { return c.canSend() == WSocketClient::err_t::ok; });
+  if (!cnt) return msgall_err_t::none;
+  return cnt == _clients.size() ? msgall_err_t::ok : msgall_err_t::partial;
+}
+
+WSocketServer::msgall_err_t WSocketServer::pingAll(const char *data, size_t len){
+  size_t cnt{0};
+  for (auto &c : _clients) {
+    if ( c.ping(data, len) == WSocketClient::err_t::ok)
+      ++cnt;
+  }
+  if (!cnt)
+    return msgall_err_t::none;
+  return cnt == _clients.size() ? msgall_err_t::ok : msgall_err_t::partial;
+}
+
+WSocketServer::msgall_err_t WSocketServer::messageAll(std::shared_ptr<WSMessageGeneric> m){
+  size_t cnt{0};
+  for (auto &c : _clients) {
+    if ( c.enqueueMessage(m) == WSocketClient::err_t::ok)
+      ++cnt;
+  }
+  if (!cnt)
+    return msgall_err_t::none;
+  return cnt == _clients.size() ? msgall_err_t::ok : msgall_err_t::partial;
+}
+
+void WSocketServer::_purgeClients(){
+  log_d("purging clients");
+  std::lock_guard lock(_lock);
+  // purge clients that are disconnected and with all messages consumed
+  std::erase_if(_clients, [](const WSocketClient& c){ return (c.status() == WSocketClient::conn_state_t::disconnected && !c.inQueueSize() ); });
+}

--- a/src/AsyncWSocket.h
+++ b/src/AsyncWSocket.h
@@ -3,7 +3,7 @@
 
 // A new experimental implementation of Async WebSockets client/server
 
-
+#if __cplusplus >= 201703L
 #pragma once
 
 #include "AsyncWebSocket.h"
@@ -945,3 +945,7 @@ private:
   void _taskRunner();
 
 };
+
+#else  // __cplusplus >= 201703L
+#warning "WSocket requires C++17, won't build"
+#endif // __cplusplus >= 201703L

--- a/src/AsyncWSocket.h
+++ b/src/AsyncWSocket.h
@@ -1,0 +1,591 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright 2016-2025 Hristo Gochkov, Mathieu Carbou, Emil Muratov
+
+// A new experimental implementation of Async WebSockets client/server
+
+
+#pragma once
+
+#include "AsyncWebSocket.h"
+
+class WSocketServer;
+
+/**
+ * @brief WebSocket message type
+ * 
+ */
+enum class WSFrameType_t : uint8_t {   // type field is 4 bits
+  continuation = 0,        // fragment of a previous message
+  text,
+  binary,
+  close = 0x08,
+  ping,
+  pong
+};
+
+/**
+ * @brief Message transition state
+ * reflects message transmission state
+ * 
+ */
+enum class WSMessageStatus_t {
+  empty = 0,      // bare message, not usefull for anything yet
+  sending,        // message in sending state
+  sent,           // message transition has been complete
+  incomlete,      // message is not complete. i.e. partially received
+  complete,       // message is complete, no new data is expected
+  error           // malformed message
+};
+
+
+
+/**
+ * @brief abstract WebSocket message
+ * 
+ */
+class WSMessageGeneric {
+  friend class WSocketClient;
+  /** Is this the last chunk in a fragmented message ?*/
+  bool _final;
+
+public:
+  const WSFrameType_t type;
+
+  WSMessageGeneric(WSFrameType_t type, bool final = true) : type(type), _final(final) {};
+  virtual ~WSMessageGeneric(){};
+
+  // if this message in final fragment
+  bool final() const { return _final; }
+
+  /**
+   * @brief Get the Size of the message
+   * 
+   * @return size_t 
+   */
+  virtual size_t getSize() const = 0;
+
+  /**
+   * @brief Get access to RO-data
+   * @note we cast it to char* 'cause of two reasons:
+   *  - the LWIP's _tcp_write() function accepts const char*
+   *  - websocket is mostly text anyway unless compressed
+   * @note for messages with type 'text' this lib will always include NULL terminator at the end of data, NULL byte is NOT included in total size of the message returned by getSize()
+   *        a care should be taken when accessing the data for messages with type 'binary', it won't have NUL terminator at the end and would be valid up to getSize() in length!
+   * @note buffer should be writtable so that client class could apply masking on data if needed
+   * @return char* const 
+   */
+  virtual char* getData() = 0;
+
+  /**
+   * @brief WebSocket message status code as defined in https://datatracker.ietf.org/doc/html/rfc6455#section-7.4
+   * 
+   * @return uint16_t 
+   */
+  virtual uint16_t getStatusCode() const { return 0; }
+
+protected:
+
+  /**
+   * @brief access message buffer in chunks
+   * this method is used internally by WSocketClient class when sending message. In simple case it just wraps around getDtata() call
+   * but could also be implemented in derived classes for chunked transfers
+   * 
+   * @return std::pair<char*, int32_t>
+   */
+  virtual std::pair<char*, size_t> getCurrentChunk(){ return std::pair(getData(), getSize()); } ;
+
+  /**
+   * @brief move to the next chunk of message data assuming current chunk has been consumed already
+   * @note nextChunk call switches the pointer, getCurrentChunk() would return new chunk afterwards
+   * 
+   * @return int32_t - size of a next chunk of data
+   * @note if returned size is '-1' then no more data chunks are available
+   * @note if returned size is '0' then next chunk is not available yet, a call should be repeated later to retreive new chunk
+   */
+  virtual int32_t getNextChunk(){ return -1; };
+
+  /**
+   * @brief add a chunk of data to the message
+   * it will NOT extend total message size, it's to reassemble a message taking several TCP packets
+   * 
+   * @param data - data chunk pointer
+   * @param len - size of a chunk
+   * @param offset - an offset for chunk from begingn of message (@note offset is for calculation reference only, the chunk is always added to the end of current message data)
+   */
+  virtual void addChunk(char* data, size_t len, size_t offset) = 0;
+
+};
+
+
+template<typename T>
+class WSMessageContainer : public WSMessageGeneric {
+protected:
+  T container;
+
+public:
+
+  WSMessageContainer(WSFrameType_t t, bool final = true) :  WSMessageGeneric(t, final) {}
+
+  // variadic constructor for anything that T can be made of
+  template<typename... Args>
+  WSMessageContainer (WSFrameType_t t, bool final, Args&&... args) : WSMessageGeneric(t, final), container(std::forward<Args>(args)...) {};
+
+  /**
+   * @copydoc WSMessageGeneric::getSize()
+   */
+  size_t getSize() const override {
+    // specialisation for Arduino String
+    if constexpr(std::is_same_v<String, std::decay_t<decltype(container)>>)
+      return container.length();
+    // otherwise we assume either STL container is used, (i.e. st::vector or std::string) or derived class should implement same methods
+    if constexpr(!std::is_same_v<String, std::decay_t<decltype(container)>>)
+      return container.size();
+  };
+
+  /**
+   * @copydoc WSMessageGeneric::getData()
+   * @details though casted to const char* the data there is NOT NULL-terminated string!
+   */
+  char* getData() override {
+    // specialization for Arduino String
+    if constexpr(std::is_same_v<String, std::decay_t<decltype(container)>>)
+      return container.c_str();
+    // otherwise we assume either STL container is used, (i.e. st::vector or std::string) or derived class should implement same methods
+    if constexpr(!std::is_same_v<String, std::decay_t<decltype(container)>>)
+      return reinterpret_cast<char*>(container.data());
+  }
+
+  // access message container object
+  T& getContainer(){ return container; }
+
+protected:
+
+  /**
+   * @copydoc WSMessageGeneric::addChunk(char* data, size_t len, size_t offset)
+   * @details though casted to const char* the data there is NOT NULL-terminated string!
+   */
+  void addChunk(char* data, size_t len, size_t offset) override {
+    // specialization for Arduino String
+    if constexpr(std::is_same_v<String, std::decay_t<decltype(container)>>){
+      container.concat(data, len);
+    }
+
+    // specialization for std::string
+    if constexpr(std::is_same_v<std::string, std::decay_t<decltype(container)>>){
+      container.append(data, len);
+    }
+
+    // specialization for std::vector
+    if constexpr(std::is_same_v<std::vector<uint8_t>, std::decay_t<decltype(container)>>){
+      container.resize(len + offset);
+      memcpy(container.data(), data, len);
+    }
+  }
+
+};
+
+/**
+ * @brief Control message - 'Close'
+ * 
+ */
+class WSMessageClose : public WSMessageContainer<std::string> {
+  const uint16_t _status_code;
+
+public:
+  /**
+   * @brief Construct Close message without the body
+   * 
+   * @param status close code as defined in https://datatracker.ietf.org/doc/html/rfc6455#section-7.4
+   */
+  WSMessageClose (uint16_t status = 1000) : WSMessageContainer<std::string>(WSFrameType_t::close, true), _status_code(status) {};
+  // variadic constructor for anything that std::string can be made of
+  template<typename... Args>
+  WSMessageClose (uint16_t status, Args&&... args) : WSMessageContainer<std::string>(WSFrameType_t::close, true, std::forward<Args>(args)...), _status_code(status) {};
+  
+  uint16_t getStatusCode() const override { return _status_code; }
+};
+
+/**
+ * @brief structure that owns the message (or fragment) while sending/receiving by WSocketClient
+ */
+struct WSMessageFrame {
+  /** Mask key */
+  uint32_t mask;
+  /** Length of the current message/fragment to be transmitted. This equals the total length of the message if num == 0 && final == true */
+  uint64_t len;
+  /** Offset of the payload data pending to be sent. Note: this is NOT websocket message fragment's size! */
+  uint64_t index;
+  /** offset in the current chunk of data, used to when sending message in chunks (not WS fragments!), for single chunged messages chunk_offset and index are same */
+  size_t chunk_offset;
+  // message object
+  std::shared_ptr<WSMessageGeneric> msg;
+};
+
+/**
+ * @brief WebSocket client instance
+ * 
+ */
+class WSocketClient {
+public:
+  // TCP connection state
+  enum class conn_state_t {
+    connected,
+    disconnecting,
+    disconnected
+  };
+
+  /**
+   * @brief WebSocket Client Events 
+   * 
+   */
+  enum class event_t {
+    connect,
+    disconnect,
+    msgRecv,
+    msgSent
+  };
+
+  // error codes
+  enum class err_t {
+    ok,                 // no problem :)
+    nospace,            // message queues are overflowed, can't accept more data
+    messageTooBig,      // can't accept such a large message
+    disconnected        // peer connection is broken
+  };
+
+  enum class overflow_t {
+    disconnect,
+    discard,
+    drophead,
+    droptail
+  };
+
+  using event_callback_t = std::function<void(WSocketClient *client, WSocketClient::event_t event)>;
+
+  // Client connection ID (increments for each new connection for the given server)
+  const uint32_t id;
+
+private:
+  AsyncClient *_client;
+  event_callback_t _cb;
+  // incoming message size limit
+  size_t _max_msgsize;
+  // cummulative maximum of the data messages held in message queues, both in and out
+  size_t _max_qcap;
+
+public:
+
+  /**
+   * @brief Construct a new WSocketClient object
+   * 
+   * @param id - client's id tag
+   * @param request - AsyncWebServerRequest which is switching the protocol to WS
+   * @param call_back - event callback handler
+   * @param msgcap - incoming message size limit, if incoming msg advertizes larger size the connection would be dropped
+   * @param qcap - in/out queues sizes (in number of messages)
+   */
+  WSocketClient(uint32_t id, AsyncWebServerRequest *request, WSocketClient::event_callback_t call_back, size_t msgsize = 8 * 1024, size_t qcap = 4);
+  ~WSocketClient();
+
+  /**
+   * @brief Enqueue message for sending
+   * 
+   * @param msg rvalue reference to message object, i.e. WSocketClient will take the ownership of the object
+   * @return err_t enqueue error status
+   */
+  err_t enqueueMessage(std::shared_ptr<WSMessageGeneric> mptr);
+
+  /**
+   * @brief retrieve message from inbout Q
+   * 
+   * @return std::shared_ptr<WSMessageGeneric>
+   * @note if Q is empty, then empty pointer is returned, so it should be validated
+   */
+  std::shared_ptr<WSMessageGeneric> dequeueMessage();
+
+  conn_state_t status() const {
+    return _connection;
+  }
+
+  AsyncClient *client() {
+    return _client;
+  }
+
+  const AsyncClient *client() const {
+    return _client;
+  }
+
+  /**
+   * @brief Set inbound queueu overflow Policy
+   * 
+   * @param policy inbound queue overflow policy
+   * 
+   * @note overflow_t::disconnect (default) - disconnect client with respective close message when inbound Q is full.
+   * This is the default behavior in yubox-node-org, which is not silently discarding messages but instead closes the connection.
+   * The big issue with this behavior is  that is can cause the UI to automatically re-create a new WS connection, which can be filled again,
+   * and so on, causing a resource exhaustion.
+   * 
+   * @note overflow_t::discard - silently discard new messages if the queue is full.
+   * This is the default behavior in the original ESPAsyncWebServer library from me-no-dev. This behavior allows the best performance at the expense of unreliable message delivery in case the queue is full.
+   * 
+   * @note overflow_t::drophead - drop the oldest message from inbound queue to fit new message
+   * @note overflow_t::droptail - drop most recent message from inbound queue to fit new message
+   * 
+   */
+  void setOverflowPolicy(overflow_t policy){ _overflow_policy = policy; }
+
+  overflow_t getOverflowPolicy() const { return _overflow_policy; }
+
+  // send control frames
+  err_t close(uint16_t code = 0, const char *message = NULL);
+  err_t ping(const char *data = NULL, size_t len = 0);
+
+  size_t inQueueSize() const { return _messageQueueIn.size(); };
+  size_t outQueueSize() const { return _messageQueueOut.size(); };
+
+  // check if client can enqueue and send new messages
+  err_t canSend() const;
+
+private:
+  conn_state_t _connection{conn_state_t::connected};
+  // frames in transit
+  WSMessageFrame _inFrame{}, _outFrame{};
+  // message queues
+  std::deque< std::shared_ptr<WSMessageGeneric> > _messageQueueIn;
+  std::deque< std::shared_ptr<WSMessageGeneric> > _messageQueueOut;
+
+#ifdef ESP32
+  // access mutex'es
+  std::mutex _sendLock;
+  mutable std::recursive_mutex _inQlock;
+  mutable std::recursive_mutex _outQlock;
+#endif
+
+  // inbound Q overflow behavior
+  overflow_t _overflow_policy{overflow_t::disconnect};
+
+  // amount of sent data in-flight, i.e. copied to socket buffer, but not acked yet from lwip side
+  size_t _in_flight{0};
+  // in-flight data credits
+  size_t _in_flight_credit{2};
+
+
+  /**
+   * @brief go through out Q and send message data ()
+   * @note this method will grab a mutex lock on outQ internally
+   * 
+   */
+  void _clientSend(size_t acked_bytes = 0);
+
+  /**
+   * @brief expell next message from out Q (if any) and start sending it to the peer
+   * @note this function will generate and add msg header to socket buffer but assumes it's callee will take care of actually sending the header and message body further
+   * @note this function assumes that it's calle has already set _outFrameLock
+   * 
+   */
+  bool _evictOutQueue();
+
+  /**
+   * @brief try to parse ws header and create a new frame message
+   * 
+   * @return size_t size of the parsed and consumed bytes from input in a new message
+   */
+  std::pair<size_t, uint16_t> _mkNewFrame(char* data, size_t len, WSMessageFrame& frame);
+
+  // AsyncTCP callbacks
+  void _onError(int8_t);
+  void _onTimeout(uint32_t time);
+  void _onDisconnect(AsyncClient *c);
+  void _onData(void *pbuf, size_t plen);
+};
+
+
+/**
+ * @brief WebServer Handler implementation that plays the role of a socket server
+ * 
+ */
+class WSocketServer : public AsyncWebHandler {
+public:
+  // error enque to all
+  enum class msgall_err_t {
+    ok = 0,         // message was enqueued for delivering to all clients
+    partial,        // some of clients queueus are full, message was not enqueued there
+    none            // no clients or all outbound queues are full, message discarded
+  };
+
+  using WSocketServerEvent_t = std::function<void(WSocketClient *client, WSocketClient::event_t event)>;
+
+
+  explicit WSocketServer(const char* url, WSocketServerEvent_t handler = {}) : _url(url), _eventHandler(handler) {}
+  ~WSocketServer() = default;
+
+  const char *url() const {
+    return _url.c_str();
+  }
+  void enable(bool e) {
+    _enabled = e;
+  }
+  bool enabled() const {
+    return _enabled;
+  }
+
+
+  /**
+   * @brief check if client with specified id can accept new message for sending
+   * 
+   * @param id 
+   * @return WSocketClient::err_t 
+   */
+  WSocketClient::err_t canSend(uint32_t id) const { return _getClient(id) ? _getClient(id)->canSend() : WSocketClient::err_t::disconnected; };
+
+  /**
+   * @brief check how many clients are available for sending data
+   * 
+   * @return msgall_err_t 
+   */
+  msgall_err_t canSend() const;
+
+  // return number of active clients
+  //size_t activeClientsCount() const { return std::count_if(std::begin(_clients), std::end(_clients), [](const WSocketClient &c) { return c.status() == WSocketClient::conn_state_t::connected; }); };
+
+  // find if there is a client with specified id
+  bool hasClient(uint32_t id) const {
+    return _getClient(id) != nullptr;
+  }
+
+  /**
+   * @brief disconnect client
+   * 
+   * @param id 
+   * @param code 
+   * @param message 
+   */
+  void close(uint32_t id, uint16_t code = 0, const char *message = NULL){ if (WSocketClient *c = _getClient(id)) { c->close(code, message); } }
+
+  /**
+   * @brief disconnect all clients
+   * 
+   * @param code 
+   * @param message 
+   */
+  void closeAll(uint16_t code = 0, const char *message = NULL){ for (auto &c : _clients) { c.close(code, message); } }
+
+  /**
+   * @brief sned ping to client
+   * 
+   * @param id 
+   * @param data 
+   * @param len 
+   * @return true 
+   * @return false 
+   */
+  WSocketClient::err_t ping(uint32_t id, const char *data = NULL, size_t len = 0){ if (WSocketClient *c = _getClient(id)) { return c->ping(data, len); } }
+
+  /**
+   * @brief send ping to all clients
+   * 
+   * @param data 
+   * @param len 
+   * @return msgall_err_t 
+   */
+  msgall_err_t pingAll(const char *data = NULL, size_t len = 0);
+
+  msgall_err_t messageAll(std::shared_ptr<WSMessageGeneric> m);
+
+
+  /*
+  bool text(uint32_t id, const uint8_t *message, size_t len);
+  bool text(uint32_t id, const char *message, size_t len);
+  bool text(uint32_t id, const char *message);
+  bool text(uint32_t id, const String &message);
+  bool text(uint32_t id, AsyncWebSocketMessageBuffer *buffer);
+  bool text(uint32_t id, AsyncWebSocketSharedBuffer buffer);
+
+  enqueue_err_t textAll(const uint8_t *message, size_t len);
+  enqueue_err_t textAll(const char *message, size_t len);
+  enqueue_err_t textAll(const char *message);
+  enqueue_err_t textAll(const String &message);
+  enqueue_err_t textAll(AsyncWebSocketMessageBuffer *buffer);
+  enqueue_err_t textAll(AsyncWebSocketSharedBuffer buffer);
+
+  bool binary(uint32_t id, const uint8_t *message, size_t len);
+  bool binary(uint32_t id, const char *message, size_t len);
+  bool binary(uint32_t id, const char *message);
+  bool binary(uint32_t id, const String &message);
+  bool binary(uint32_t id, AsyncWebSocketMessageBuffer *buffer);
+  bool binary(uint32_t id, AsyncWebSocketSharedBuffer buffer);
+
+  enqueue_err_t binaryAll(const uint8_t *message, size_t len);
+  enqueue_err_t binaryAll(const char *message, size_t len);
+  enqueue_err_t binaryAll(const char *message);
+  enqueue_err_t binaryAll(const String &message);
+  enqueue_err_t binaryAll(AsyncWebSocketMessageBuffer *buffer);
+  enqueue_err_t binaryAll(AsyncWebSocketSharedBuffer buffer);
+
+  size_t printf(uint32_t id, const char *format, ...) __attribute__((format(printf, 3, 4)));
+  size_t printfAll(const char *format, ...) __attribute__((format(printf, 2, 3)));
+*/
+
+  void handleHandshake(AwsHandshakeHandler handler) {
+    _handshakeHandler = handler;
+  }
+
+  /**
+   * @brief access clients list
+   * @note manipulating the list of clients without the locking could be dangerous!
+   * 
+   * @return std::list<WSocketClient>& 
+   */
+  std::list<WSocketClient> &getClients() {
+    return _clients;
+  }
+
+  // return next available client's ID
+  uint32_t getNextId() {
+    return ++_cNextId;
+  }
+
+  /**
+   * @brief callback for AsyncServe - onboard new ws client
+   * 
+   * @param request 
+   * @return true 
+   * @return false 
+   */
+  bool newClient(AsyncWebServerRequest *request);
+
+private:
+  String _url;
+  WSocketServerEvent_t _eventHandler;
+  AwsHandshakeHandler _handshakeHandler;
+  std::list<WSocketClient> _clients;
+  uint32_t _cNextId{0};
+  bool _enabled{true};
+  #ifdef ESP32
+  std::mutex _lock;
+  #endif
+
+
+  /**
+   * @brief Get ptr to client with specified id
+   * 
+   * @param id 
+   * @return WSocketClient* - nullptr if client not founc
+   */
+  WSocketClient* _getClient(uint32_t id);
+  WSocketClient const* _getClient(uint32_t id) const;
+
+  /**
+   * @brief go through clients list and remove those ones that are disconnected and have no messages pending
+   * 
+   */
+  void _purgeClients();
+
+  // WSocketClient events handler
+  void _clientEvents(WSocketClient *client, WSocketClient::event_t event);
+
+  // WebServer methods
+  bool canHandle(AsyncWebServerRequest *request) const override final { return _enabled && request->isWebSocketUpgrade() && request->url().equals(_url); };
+  void handleRequest(AsyncWebServerRequest *request) override final;
+
+};

--- a/src/AsyncWSocket.h
+++ b/src/AsyncWSocket.h
@@ -567,6 +567,8 @@ private:
 
   // amount of sent data in-flight, i.e. copied to socket buffer, but not acked yet from lwip side
   size_t _in_flight{0};
+  // counter for consumed data from tcp_pcbs, but delayd ack to hold the window
+  size_t _pending_ack{0};
 
   // keepalive
   unsigned long _keepAlivePeriod{0}, _lastPong;
@@ -606,6 +608,7 @@ private:
   void _onTimeout(uint32_t time);
   void _onDisconnect(AsyncClient *c);
   void _onData(void *pbuf, size_t plen);
+  void _onPoll(AsyncClient *c);
 };
 
 /**
@@ -658,6 +661,7 @@ public:
 
   /**
    * @copydoc WSClient::setOverflowPolicy(overflow_t policy)
+   * @note default is 'disconnect'
    */
   void setOverflowPolicy(WSocketClient::overflow_t policy){ _overflow_policy = policy; }
   WSocketClient::overflow_t getOverflowPolicy() const { return _overflow_policy; }

--- a/src/AsyncWebSocket.h
+++ b/src/AsyncWebSocket.h
@@ -445,7 +445,8 @@ public:
   uint32_t _getNextId() {
     return _cNextId++;
   }
-  AsyncWebSocketClient *_newClient(AsyncWebServerRequest *request);
+  // callback function that takes the ownership of the connected client, called from a AsyncWebSocketResponse instance
+  bool newClient(AsyncWebServerRequest *request);
   void _handleDisconnect(AsyncWebSocketClient *client);
   void _handleEvent(AsyncWebSocketClient *client, AwsEventType type, void *arg, uint8_t *data, size_t len);
   bool canHandle(AsyncWebServerRequest *request) const override final;
@@ -464,10 +465,10 @@ public:
 class AsyncWebSocketResponse : public AsyncWebServerResponse {
 private:
   String _content;
-  AsyncWebSocket *_server;
+  AwsHandshakeHandler _callback;
 
 public:
-  AsyncWebSocketResponse(const String &key, AsyncWebSocket *server);
+  AsyncWebSocketResponse(const String &key, AwsHandshakeHandler cb);
   void _respond(AsyncWebServerRequest *request);
   size_t _ack(AsyncWebServerRequest *request, size_t len, uint32_t time);
   bool _sourceValid() const {

--- a/wsocket_examples/MultiEndpoint/MultiEndpoint.ino
+++ b/wsocket_examples/MultiEndpoint/MultiEndpoint.ino
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright 2016-2025 Hristo Gochkov, Mathieu Carbou, Emil Muratov
+
+/*
+  this example shows how to handle multiple websocket endpoints within same server instance
+
+*/
+
+#include <AsyncWSocket.h>
+#include <WiFi.h>
+#include "endpoints.h"
+
+#define WIFI_SSID "your_ssid"
+#define WIFI_PASSWD "your_pass"
+
+// WebSocket endpoints to serve
+constexpr const char WSENDPOINT_DEFAULT[] = "/ws";      // default endpoint - used for logging messages
+constexpr const char WSENDPOINT_ECHO[] = "/wsecho";     // echo server - it replies back messages it receives
+constexpr const char WSENDPOINT_SPEED[] = "/wsspeed";   // upstream speed test - sending large data chunks from server to browser
+
+// *** Event handlers ***
+// WS Events dispatcher
+void wsEventDispatcher(WSocketClient *client, WSocketClient::event_t event);
+// speed tester
+void wsSpeedService(WSocketClient *client, WSocketClient::event_t event);
+// echo service
+void wsEchoService(WSocketClient *client, WSocketClient::event_t event);
+// default service
+void wsDefaultService(WSocketClient *client, WSocketClient::event_t event);
+
+// Web Sever
+AsyncWebServer server(80);
+// WebSocket server instance
+WSocketServer ws(WSENDPOINT_DEFAULT, wsEventDispatcher);
+
+// this function is attached as main callback function for websocket events
+void wsEventDispatcher(WSocketClient *client, WSocketClient::event_t event){
+  if (event == WSocketClient::event_t::connect || event == WSocketClient::event_t::disconnect){
+    // report all new connections to default endpoint
+    char buff[100];
+    snprintf(buff, 100, "Client %s, id:%lu, IP:%s:%u\n",
+        event == WSocketClient::event_t::connect ? "connected" : "disconnected" ,
+        client->id,
+        IPAddress (client->client()->getRemoteAddress4().addr).toString().c_str(),
+        client->client()->getRemotePort()
+    );
+    // send message to clients connected to default /ws endpoint
+    ws.textToEndpoint(WSENDPOINT_DEFAULT, buff);
+    Serial.print(buff);
+  }
+
+  // here we identify on which endpoint we received and event and dispatch to the corresponding handler
+  switch (client->getURLHash())
+  {
+    case asyncsrv::hash_djb2a(WSENDPOINT_ECHO) :
+      wsEchoService(client, event);
+      break;
+
+      case asyncsrv::hash_djb2a(WSENDPOINT_SPEED) :
+      wsSpeedService(client, event);
+      break;
+    
+    default:
+      wsDefaultService(client, event);
+      break;
+  }
+
+}
+
+
+// default service - we will use it for event logging and information reports
+void wsDefaultService(WSocketClient *client, WSocketClient::event_t event){
+  switch (event){
+    case WSocketClient::event_t::msgRecv : {
+      // we do nothing but discard messages here (if any), no use for now
+      client->dequeueMessage();
+      break;
+    }
+
+    default:;
+  }  
+}
+
+// default service - we will use it for event logging and information reports
+void wsEchoService(WSocketClient *client, WSocketClient::event_t event){
+  switch (event){
+    case WSocketClient::event_t::connect : {
+      ws.text(client->id, "Hello Client, this is an echo endpoint, message me something and I will reply it back");
+      break;
+    }
+
+    // incoming message
+    case WSocketClient::event_t::msgRecv : {
+      auto m = client->dequeueMessage();
+      if (m->type == WSFrameType_t::text){
+        // got a text message, reformat it and reply
+        std::string msg("Your message was: ");
+        msg.append(m->getData());
+        // avoid copy and move string to message queue
+        ws.text(client->id, std::move(msg));
+      }
+
+      break;
+    }
+    default:;
+  }  
+}
+
+
+// for speed test load
+uint8_t *buff = nullptr;
+size_t buff_size = 32 * 1024; // will send 32k message buffer
+//size_t cnt{0};
+// a unique stream id - it is used to avoid sending dublicate frames when multiple clients connected to speedtest endpoint
+uint32_t client_id{0};
+
+void bulkSend(uint32_t token){
+  if (!buff) return;
+  if (client_id == 0){
+    // first client connected grabs the stream
+    client_id = token;
+  } else if (token != client_id) {
+    // we will send next frame only upon delivery the previous one to client owning the stream, for others we ignore
+    // this is to avoid stacking new frames in the Q when multiple clients are connected to the server
+    return;
+  }
+
+  // generate metadata info frame
+  // this text frame will carry our resources stat
+  char msg[120];
+  snprintf(msg, 120, "FrameSize:%u, Mem:%lu, psram:%lu, token:%lu", buff_size, ESP.getFreeHeap(), ESP.getFreePsram(), client_id);
+
+  ws.textToEndpoint(WSENDPOINT_SPEED, msg);
+
+  // here we MUST ensure that client owning the stream is able to send data, otherwise recursion would crash controller
+  if (ws.clientState(client_id) == WSocketClient::err_t::ok){
+    // for bulk load sending we will use WSMessageStaticBlob object, it will directly send
+    // payload to websocket peers without intermediate buffer copies and
+    // it is the most efficient way to send large objects from memory/ROM
+    auto m = std::make_shared<WSMessageStaticBlob>(
+      WSFrameType_t::binary,    // bynary message
+      true,                     // final message
+      reinterpret_cast<const char*>(buff), buff_size, // buffer to transfer
+      // the key here to understand when frame buffer completes delivery - for this we set
+      // the callback back to ourself, so that when when
+      // this frame would complete delivery, this function is called again to obtain a new frame buffer from camera
+      [](WSMessageStatus_t s, uint32_t t){ bulkSend(t); },
+      client_id   // message token
+    );
+    // send message to all peers of this endpoint
+    ws.messageToEndpoint(WSENDPOINT_SPEED, m);
+    //++cnt;
+  } else {
+    client_id = 0;
+  }
+}
+
+// speed tester - this endpoint will send bulk dummy payload to anyone who connects here
+void wsSpeedService(WSocketClient *client, WSocketClient::event_t event){
+  switch (event){
+    case WSocketClient::event_t::connect : {
+      // prepare a buffer with some junk data
+      if (!buff)
+        buff = (uint8_t*)malloc(buff_size);
+      // start an endless bulk transfer
+      bulkSend(client->id);
+      break;
+    }
+
+    // incoming message
+    case WSocketClient::event_t::msgRecv : {
+      // silently discard here everything comes in
+      client->dequeueMessage();
+      }
+      break;
+
+    case WSocketClient::event_t::disconnect :
+      // if no more clients are connected, release memory
+      if ( ws.activeEndpointClientsCount(WSENDPOINT_SPEED) == 0){
+        delete buff;
+        buff = nullptr;
+      }
+      break;
+
+    default:;
+  }  
+
+}
+
+
+
+// setup our server
+void setup() {
+  Serial.begin(115200);
+
+#ifndef CONFIG_IDF_TARGET_ESP32H2
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(WIFI_SSID, WIFI_PASSWD);
+  //WiFi.softAP("esp-captive");
+#endif
+  // Wait for connection
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(250);
+    Serial.print(".");
+  }
+  Serial.println("");
+  Serial.print("Connected to ");
+  //Serial.println(ssid);
+  Serial.print("IP address: ");
+  Serial.println(WiFi.localIP());
+  Serial.printf("Open the browser and connect to http://%s/\n", WiFi.localIP());
+
+  // HTTP endpoint
+  server.on("/", HTTP_GET, [](AsyncWebServerRequest *request) {
+    // need to cast to uint8_t*
+    // if you do not, the const char* will be copied in a temporary String buffer
+    request->send(200, "text/html", (uint8_t *)htmlPage, std::string_view(htmlPage).length());
+  });
+
+  // add endpoint for bulk speed testing
+  ws.addURLendpoint("/wsspeed");
+
+  // add endpoint for message echo testing
+  ws.addURLendpoint("/wsecho");
+
+  // attach WebSocket server to web server
+  server.addHandler(&ws);
+
+  // start server
+  server.begin();
+
+  //log_e("e setup end");
+  //log_w("w server started");
+  //log_d("d server debug");
+}
+
+
+void loop() {
+  // nothing to do here
+  vTaskDelete(NULL);
+}

--- a/wsocket_examples/MultiEndpoint/endpoints.h
+++ b/wsocket_examples/MultiEndpoint/endpoints.h
@@ -1,0 +1,837 @@
+// this page provides minimalistic WebSocket testing dashboard
+// disclaimer: this page and code was generated with the help of DeepSeek AI tool
+
+static const char *htmlPage = R"(
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>WebSocket Dashboard</title>
+    <!-- disclaimer: this page and code was generated with the help of DeepSeek AI tool -->
+    <style>
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    min-height: 100vh;
+    padding: 20px;
+}
+
+.container {
+    max-width: 1000px;
+    margin: 0 auto;
+    background: white;
+    border-radius: 15px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+    overflow: hidden;
+}
+
+h1 {
+    background: linear-gradient(135deg, #2c3e50, #3498db);
+    color: white;
+    padding: 20px;
+    text-align: center;
+    font-size: 1.5em;
+}
+
+.section {
+    border-bottom: 1px solid #e9ecef;
+}
+
+.section:last-child {
+    border-bottom: none;
+}
+
+.section-header {
+    padding: 15px 20px;
+    background: #f8f9fa;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 15px;
+}
+
+.section-header h2 {
+    color: #2c3e50;
+    font-size: 1.2em;
+}
+
+.controls {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+    flex-wrap: wrap;
+}
+
+button {
+    padding: 8px 16px;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-weight: bold;
+    transition: all 0.3s ease;
+    font-size: 0.9em;
+}
+
+.btn-connect {
+    background: #28a745;
+    color: white;
+}
+
+.btn-connect:hover:not(:disabled) {
+    background: #218838;
+    transform: translateY(-1px);
+}
+
+.btn-disconnect {
+    background: #dc3545;
+    color: white;
+}
+
+.btn-disconnect:hover:not(:disabled) {
+    background: #c82333;
+    transform: translateY(-1px);
+}
+
+button:disabled {
+    background: #6c757d;
+    cursor: not-allowed;
+    transform: none !important;
+}
+
+.status {
+    font-weight: bold;
+    font-size: 0.9em;
+}
+
+.status-disconnected {
+    background: #f8d7da;
+    color: #721c24;
+    padding: 4px 8px;
+    border-radius: 12px;
+}
+
+.status-connecting {
+    background: #fff3cd;
+    color: #856404;
+    padding: 4px 8px;
+    border-radius: 12px;
+}
+
+.status-connected {
+    background: #d4edda;
+    color: #155724;
+    padding: 4px 8px;
+    border-radius: 12px;
+}
+
+/* Log Messages */
+.log-container {
+    padding: 15px;
+}
+
+.messages-box {
+    height: 200px;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    padding: 10px;
+    overflow-y: auto;
+    background: #fafafa;
+    font-family: 'Courier New', monospace;
+    font-size: 0.85em;
+    line-height: 1.4;
+}
+
+.log-message {
+    margin-bottom: 4px;
+    padding: 2px 4px;
+    border-radius: 3px;
+}
+
+.log-message.info {
+    background: #e3f2fd;
+    border-left: 3px solid #2196f3;
+}
+
+.log-message.error {
+    background: #ffebee;
+    border-left: 3px solid #f44336;
+    color: #c62828;
+}
+
+.log-message.warning {
+    background: #fff8e1;
+    border-left: 3px solid #ff9800;
+    color: #ef6c00;
+}
+
+/* Chat Section */
+.chat-container {
+    padding: 15px;
+}
+
+.input-container {
+    display: flex;
+    gap: 10px;
+    margin-top: 10px;
+}
+
+#messageInput {
+    flex: 1;
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 5px;
+    font-size: 0.9em;
+}
+
+#messageInput:focus {
+    outline: none;
+    border-color: #3498db;
+}
+
+#sendBtn {
+    background: #3498db;
+    color: white;
+    padding: 10px 20px;
+}
+
+#sendBtn:hover:not(:disabled) {
+    background: #2980b9;
+}
+
+.chat-message {
+    margin-bottom: 8px;
+    padding: 8px;
+    border-radius: 5px;
+}
+
+.chat-message.sent {
+    background: #e3f2fd;
+    border-left: 3px solid #2196f3;
+    text-align: right;
+}
+
+.chat-message.received {
+    background: #f5f5f5;
+    border-left: 3px solid #4caf50;
+}
+
+/* Stats Section */
+.stats-container {
+    padding: 20px;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 15px;
+}
+
+.stat-item {
+    background: #f8f9fa;
+    padding: 15px;
+    border-radius: 8px;
+    border-left: 4px solid #3498db;
+}
+
+.stat-item label {
+    display: block;
+    font-weight: bold;
+    color: #2c3e50;
+    margin-bottom: 5px;
+    font-size: 0.9em;
+}
+
+.stat-item span {
+    font-family: 'Courier New', monospace;
+    font-size: 1.1em;
+    color: #e74c3c;
+    font-weight: bold;
+}
+
+/* Scrollbar styling */
+.messages-box::-webkit-scrollbar {
+    width: 6px;
+}
+
+.messages-box::-webkit-scrollbar-track {
+    background: #f1f1f1;
+    border-radius: 3px;
+}
+
+.messages-box::-webkit-scrollbar-thumb {
+    background: #c1c1c1;
+    border-radius: 3px;
+}
+
+.messages-box::-webkit-scrollbar-thumb:hover {
+    background: #a8a8a8;
+}
+
+@media (max-width: 768px) {
+    .container {
+        margin: 10px;
+    }
+    
+    .section-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+    
+    .controls {
+        width: 100%;
+        justify-content: space-between;
+    }
+    
+    .stats-grid {
+        grid-template-columns: 1fr;
+    }
+    
+    .input-container {
+        flex-direction: column;
+    }
+    
+    #sendBtn {
+        width: 100%;
+    }
+}
+
+.header {
+    background: linear-gradient(135deg, #2c3e50, #3498db);
+    color: white;
+    padding: 20px;
+    text-align: center;
+}
+
+.header h1 {
+    margin: 0;
+    padding: 0;
+    background: none;
+}
+
+.server-info {
+    margin-top: 10px;
+    font-size: 0.9em;
+    opacity: 0.9;
+}
+
+.server-info span {
+    font-family: 'Courier New', monospace;
+    background: rgba(255, 255, 255, 0.2);
+    padding: 2px 6px;
+    border-radius: 3px;
+}
+
+.endpoint {
+    font-size: 0.7em;
+    background: #3498db;
+    color: white;
+    padding: 2px 8px;
+    border-radius: 10px;
+    margin-left: 8px;
+    font-weight: normal;
+    font-family: 'Courier New', monospace;
+}
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>WebSocket Dashboard</h1>
+            <div class="server-info">
+                Server: <span id="serverAddress">ws://localhost:8080</span>
+            </div>
+        </div>
+        
+        <!-- Log Messages Section -->
+        <div class="section">
+            <div class="section-header">
+                <h2>Log Messages <span class="endpoint">/ws</span></h2>
+                <div class="status">
+                    Status: <span id="logStatus" class="status-disconnected">Disconnected</span>
+                </div>
+            </div>
+            <div class="log-container">
+                <div id="logMessages" class="messages-box" title="WebSocket endpoint: /ws"></div>
+            </div>
+        </div>
+
+        <!-- Echo Chat Section -->
+        <div class="section">
+            <div class="section-header">
+                <h2>Echo Chat <span class="endpoint">/wsecho</span></h2>
+                <div class="controls">
+                    <button id="echoConnectBtn" class="btn-connect">Connect</button>
+                    <button id="echoDisconnectBtn" class="btn-disconnect" disabled>Disconnect</button>
+                    <div class="status">
+                        Status: <span id="echoStatus" class="status-disconnected">Disconnected</span>
+                    </div>
+                </div>
+            </div>
+            <div class="chat-container">
+                <div id="echoMessages" class="messages-box" title="WebSocket endpoint: /wsecho"></div>
+                <div class="input-container">
+                    <input type="text" id="messageInput" placeholder="Type your message..." disabled>
+                    <button id="sendBtn" disabled>Send</button>
+                </div>
+            </div>
+        </div>
+
+        <!-- Speed Test Section -->
+        <div class="section">
+            <div class="section-header">
+                <h2>Speed Test <span class="endpoint">/wsspeed</span></h2>
+                <div class="controls">
+                    <button id="speedConnectBtn" class="btn-connect">Connect</button>
+                    <button id="speedDisconnectBtn" class="btn-disconnect" disabled>Disconnect</button>
+                    <div class="status">
+                        Status: <span id="speedStatus" class="status-disconnected">Disconnected</span>
+                    </div>
+                </div>
+            </div>
+            <div class="stats-container">
+                <div class="stats-grid">
+                    <div class="stat-item">
+                        <label>FPS:</label>
+                        <span id="fpsCounter">0</span>
+                    </div>
+                    <div class="stat-item">
+                        <label>Frame Count:</label>
+                        <span id="frameCounter">0</span>
+                    </div>
+                    <div class="stat-item">
+                        <label>Incoming Data Rate:</label>
+                        <span id="dataRate">0 B/s</span>
+                    </div>
+                    <div class="stat-item">
+                        <label>Total Data:</label>
+                        <span id="totalData">0 B</span>
+                    </div>
+                    <div class="stat-item">
+                        <label>Avg Frame Size:</label>
+                        <span id="avgFrameSize">0 B</span>
+                    </div>
+                    <div class="stat-item">
+                        <label>Connection Time:</label>
+                        <span id="connectionTime">0s</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+class WebSocketDashboard {
+    constructor() {
+        this.baseUrl = 'ws://' + location.host; // Change to your server URL
+        
+        // WebSocket connections
+        this.logWs = null;
+        this.echoWs = null;
+        this.speedWs = null;
+        
+        // Message storage
+        this.logMessages = [];
+        this.echoMessages = [];
+        this.maxLogMessages = 100;
+        
+        // Speed test statistics
+        this.speedStats = {
+            frameCount: 0,
+            totalBytes: 0,
+            startTime: 0,
+            lastFpsUpdate: 0,
+            framesThisSecond: 0,
+            currentFps: 0,
+            dataRate: 0,
+            connectionTimer: 0,
+            isConnected: false
+        };
+        
+        this.initializeElements();
+        this.initializeEventListeners();
+        this.connectLogWebSocket();
+        this.updateStatsDisplay();
+    }
+
+    initializeElements() {
+        // Server info
+        this.serverAddressElement = document.getElementById('serverAddress');
+        this.serverAddressElement.textContent = this.baseUrl;
+        
+        // Status elements
+        this.logStatusElement = document.getElementById('logStatus');
+        this.echoStatusElement = document.getElementById('echoStatus');
+        this.speedStatusElement = document.getElementById('speedStatus');
+        
+        // Message containers
+        this.logMessagesElement = document.getElementById('logMessages');
+        this.echoMessagesElement = document.getElementById('echoMessages');
+        
+        // Buttons
+        this.echoConnectBtn = document.getElementById('echoConnectBtn');
+        this.echoDisconnectBtn = document.getElementById('echoDisconnectBtn');
+        this.speedConnectBtn = document.getElementById('speedConnectBtn');
+        this.speedDisconnectBtn = document.getElementById('speedDisconnectBtn');
+        this.sendBtn = document.getElementById('sendBtn');
+        this.messageInput = document.getElementById('messageInput');
+        
+        // Stats elements
+        this.fpsCounter = document.getElementById('fpsCounter');
+        this.frameCounter = document.getElementById('frameCounter');
+        this.dataRate = document.getElementById('dataRate');
+        this.totalData = document.getElementById('totalData');
+        this.avgFrameSize = document.getElementById('avgFrameSize');
+        this.connectionTime = document.getElementById('connectionTime');
+    }
+
+    initializeEventListeners() {
+        // Echo chat buttons
+        this.echoConnectBtn.addEventListener('click', () => this.connectEchoWebSocket());
+        this.echoDisconnectBtn.addEventListener('click', () => this.disconnectEchoWebSocket());
+        
+        // Speed test buttons
+        this.speedConnectBtn.addEventListener('click', () => this.connectSpeedWebSocket());
+        this.speedDisconnectBtn.addEventListener('click', () => this.disconnectSpeedWebSocket());
+        
+        // Chat input
+        this.sendBtn.addEventListener('click', () => this.sendMessage());
+        this.messageInput.addEventListener('keypress', (e) => {
+            if (e.key === 'Enter') {
+                this.sendMessage();
+            }
+        });
+    }
+
+    // Log WebSocket (/ws)
+    connectLogWebSocket() {
+        try {
+            this.logWs = new WebSocket(`${this.baseUrl}/ws`);
+            
+            this.logWs.onopen = () => {
+                this.updateStatus(this.logStatusElement, 'connected', 'Connected');
+                this.addLogMessage('info', 'Log WebSocket connected');
+            };
+            
+            this.logWs.onmessage = (event) => {
+                this.addLogMessage('info', event.data);
+            };
+            
+            this.logWs.onclose = (event) => {
+                this.updateStatus(this.logStatusElement, 'disconnected', 'Disconnected');
+                this.addLogMessage('warning', `Log WebSocket disconnected: ${event.code} ${event.reason || ''}`);
+                
+                // Auto-reconnect after 3 seconds
+                setTimeout(() => {
+                    if (!this.logWs || this.logWs.readyState === WebSocket.CLOSED) {
+                        this.connectLogWebSocket();
+                    }
+                }, 3000);
+            };
+            
+            this.logWs.onerror = (error) => {
+                this.addLogMessage('error', 'Log WebSocket error');
+            };
+            
+        } catch (error) {
+            this.addLogMessage('error', `Failed to connect to log WebSocket: ${error}`);
+        }
+    }
+
+    // Echo Chat WebSocket (/wsecho)
+    connectEchoWebSocket() {
+        try {
+            this.echoWs = new WebSocket(`${this.baseUrl}/wsecho`);
+            
+            this.echoWs.onopen = () => {
+                this.updateStatus(this.echoStatusElement, 'connected', 'Connected');
+                this.toggleEchoButtons(true);
+                this.addEchoMessage('system', 'Connected to echo server');
+            };
+            
+            this.echoWs.onmessage = (event) => {
+                this.addEchoMessage('received', event.data);
+            };
+            
+            this.echoWs.onclose = (event) => {
+                this.updateStatus(this.echoStatusElement, 'disconnected', 'Disconnected');
+                this.toggleEchoButtons(false);
+                this.addEchoMessage('system', 'Disconnected from echo server');
+            };
+            
+            this.echoWs.onerror = (error) => {
+                this.addEchoMessage('system', 'Connection error');
+            };
+            
+        } catch (error) {
+            this.addEchoMessage('system', `Failed to connect: ${error}`);
+        }
+    }
+
+    disconnectEchoWebSocket() {
+        if (this.echoWs) {
+            this.echoWs.close(1000, 'User disconnected');
+            this.echoWs = null;
+        }
+    }
+
+    // Speed Test WebSocket (/wsspeed)
+    connectSpeedWebSocket() {
+        try {
+            this.speedWs = new WebSocket(`${this.baseUrl}/wsspeed`);
+            this.speedWs.binaryType = 'arraybuffer';
+            
+            this.resetSpeedStats();
+            
+            this.speedWs.onopen = () => {
+                this.updateStatus(this.speedStatusElement, 'connected', 'Connected');
+                this.toggleSpeedButtons(true);
+                this.speedStats.startTime = Date.now();
+                this.speedStats.isConnected = true;
+                this.startConnectionTimer();
+            };
+            
+            this.speedWs.onmessage = (event) => {
+                if (event.data instanceof ArrayBuffer) {
+                    this.processSpeedFrame(event.data);
+                }
+            };
+            
+            this.speedWs.onclose = (event) => {
+                this.updateStatus(this.speedStatusElement, 'disconnected', 'Disconnected');
+                this.toggleSpeedButtons(false);
+                this.speedStats.isConnected = false;
+                this.stopConnectionTimer();
+            };
+            
+            this.speedWs.onerror = (error) => {
+                console.error('Speed WebSocket error:', error);
+                this.speedStats.isConnected = false;
+                this.stopConnectionTimer();
+            };
+            
+        } catch (error) {
+            console.error('Failed to connect to speed WebSocket:', error);
+        }
+    }
+
+    disconnectSpeedWebSocket() {
+        if (this.speedWs) {
+            this.speedWs.close(1000, 'User disconnected');
+            this.speedWs = null;
+            this.speedStats.isConnected = false;
+            this.stopConnectionTimer();
+        }
+    }
+
+    startConnectionTimer() {
+        if (this.speedStats.connectionTimer) {
+            clearInterval(this.speedStats.connectionTimer);
+        }
+        
+        this.speedStats.connectionTimer = setInterval(() => {
+            if (this.speedStats.isConnected) {
+                const connectionTime = Math.floor((Date.now() - this.speedStats.startTime) / 1000);
+                this.connectionTime.textContent = `${connectionTime}s`;
+            }
+        }, 1000);
+    }
+
+    stopConnectionTimer() {
+        if (this.speedStats.connectionTimer) {
+            clearInterval(this.speedStats.connectionTimer);
+            this.speedStats.connectionTimer = 0;
+        }
+    }
+
+    processSpeedFrame(arrayBuffer) {
+        const frameSize = arrayBuffer.byteLength;
+        
+        // Update statistics
+        this.speedStats.frameCount++;
+        this.speedStats.totalBytes += frameSize;
+        
+        // Calculate FPS
+        const now = performance.now();
+        if (now >= this.speedStats.lastFpsUpdate + 1000) {
+            this.speedStats.currentFps = this.speedStats.framesThisSecond;
+            
+            // Calculate data rate (bytes per second)
+            const avgFrameSize = this.speedStats.frameCount > 0 ? 
+                this.speedStats.totalBytes / this.speedStats.frameCount : 0;
+            this.speedStats.dataRate = this.speedStats.framesThisSecond * avgFrameSize;
+            
+            this.speedStats.framesThisSecond = 0;
+            this.speedStats.lastFpsUpdate = now;
+        }
+        this.speedStats.framesThisSecond++;
+    }
+
+    resetSpeedStats() {
+        this.speedStats = {
+            frameCount: 0,
+            totalBytes: 0,
+            startTime: 0,
+            lastFpsUpdate: 0,
+            framesThisSecond: 0,
+            currentFps: 0,
+            dataRate: 0,
+            connectionTimer: 0,
+            isConnected: false
+        };
+        
+        // Reset display values
+        this.fpsCounter.textContent = '0';
+        this.frameCounter.textContent = '0';
+        this.dataRate.textContent = '0 B/s';
+        this.totalData.textContent = '0 B';
+        this.avgFrameSize.textContent = '0 B';
+        this.connectionTime.textContent = '0s';
+    }
+
+    // Message handling
+    addLogMessage(type, message) {
+        const timestamp = new Date().toLocaleTimeString();
+        const logEntry = {
+            type,
+            message: `[${timestamp}] ${message}`,
+            timestamp: Date.now()
+        };
+        
+        // Add to end (bottom) for normal scrolling
+        this.logMessages.push(logEntry);
+        
+        // Keep only last 100 messages
+        if (this.logMessages.length > this.maxLogMessages) {
+            this.logMessages = this.logMessages.slice(-this.maxLogMessages);
+        }
+        
+        this.updateLogDisplay();
+    }
+
+    updateLogDisplay() {
+        this.logMessagesElement.innerHTML = '';
+        
+        this.logMessages.forEach(entry => {
+            const messageElement = document.createElement('div');
+            messageElement.className = `log-message ${entry.type}`;
+            messageElement.textContent = entry.message;
+            this.logMessagesElement.appendChild(messageElement);
+        });
+        
+        // Auto-scroll to bottom to show latest messages
+        this.logMessagesElement.scrollTop = this.logMessagesElement.scrollHeight;
+    }
+
+    addEchoMessage(type, message) {
+        const messageElement = document.createElement('div');
+        messageElement.className = `chat-message ${type}`;
+        
+        const timestamp = new Date().toLocaleTimeString();
+        
+        if (type === 'sent') {
+            messageElement.textContent = `You: ${message}`;
+        } else if (type === 'received') {
+            messageElement.textContent = `Echo: ${message}`;
+        } else {
+            messageElement.textContent = `[${timestamp}] ${message}`;
+            messageElement.style.fontStyle = 'italic';
+            messageElement.style.color = '#666';
+        }
+        
+        this.echoMessagesElement.appendChild(messageElement);
+        this.echoMessagesElement.scrollTop = this.echoMessagesElement.scrollHeight;
+        
+        // Keep reasonable history
+        if (this.echoMessagesElement.children.length > 50) {
+            this.echoMessagesElement.removeChild(this.echoMessagesElement.firstChild);
+        }
+    }
+
+    sendMessage() {
+        const message = this.messageInput.value.trim();
+        if (message && this.echoWs && this.echoWs.readyState === WebSocket.OPEN) {
+            this.echoWs.send(message);
+            this.addEchoMessage('sent', message);
+            this.messageInput.value = '';
+        }
+    }
+
+    // UI Updates
+    updateStatus(element, statusClass, text) {
+        element.className = `status-${statusClass}`;
+        element.textContent = text;
+    }
+
+    toggleEchoButtons(connected) {
+        this.echoConnectBtn.disabled = connected;
+        this.echoDisconnectBtn.disabled = !connected;
+        this.messageInput.disabled = !connected;
+        this.sendBtn.disabled = !connected;
+    }
+
+    toggleSpeedButtons(connected) {
+        this.speedConnectBtn.disabled = connected;
+        this.speedDisconnectBtn.disabled = !connected;
+    }
+
+    updateStatsDisplay() {
+        // Update FPS
+        this.fpsCounter.textContent = this.speedStats.currentFps;
+        
+        // Update frame count
+        this.frameCounter.textContent = this.speedStats.frameCount;
+        
+        // Update data rate (already labeled as "Incoming Data Rate" in HTML)
+        this.dataRate.textContent = this.formatBytes(this.speedStats.dataRate) + '/s';
+        
+        // Update total data
+        this.totalData.textContent = this.formatBytes(this.speedStats.totalBytes);
+        
+        // Update average frame size
+        const avgSize = this.speedStats.frameCount > 0 ? 
+            this.speedStats.totalBytes / this.speedStats.frameCount : 0;
+        this.avgFrameSize.textContent = this.formatBytes(avgSize);
+        
+        // Connection time is now updated by the timer, so we don't need to update it here
+        
+        // Continue updating
+        requestAnimationFrame(() => this.updateStatsDisplay());
+    }
+
+    formatBytes(bytes) {
+        if (bytes === 0 || isNaN(bytes)) return '0 B';
+        
+        const k = 1024;
+        const sizes = ['B', 'KB', 'MB', 'GB'];
+        const i = Math.floor(Math.log(bytes) / Math.log(k));
+        
+        return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+    }
+}
+
+// Initialize the dashboard when the page loads
+document.addEventListener('DOMContentLoaded', () => {
+    window.dashboard = new WebSocketDashboard();
+});
+
+// Handle page beforeunload to properly close connections
+window.addEventListener('beforeunload', () => {
+    const dashboard = window.dashboard;
+    if (dashboard) {
+        if (dashboard.logWs) dashboard.logWs.close(1000, 'Page unloading');
+        if (dashboard.echoWs) dashboard.echoWs.close(1000, 'Page unloading');
+        if (dashboard.speedWs) dashboard.speedWs.close(1000, 'Page unloading');
+    }
+});    
+    </script>
+</body>
+</html>
+)";

--- a/wsocket_examples/VideoStreaming/VideoStreaming.ino
+++ b/wsocket_examples/VideoStreaming/VideoStreaming.ino
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright 2016-2025 Hristo Gochkov, Mathieu Carbou, Emil Muratov
+
+//
+// MJPEG Cam Video streaming over WebSockets using AI-Thinker ESP32-CAM module
+// you would need a module with camera to run this example https://www.espboards.dev/esp32/esp32cam/
+
+/*
+  This example implements a WebCam streaming in browser using cheap ESP32-cam module.
+  The feature here is that frames are trasfered to the browser via WebSockets,
+  it has several advantages over traditional streamed multipart content via HTTP
+   - websockets delivers each frame in a separate message
+   - webserver is not blocked when stream is flowing, you can still send/receive other data via HTTP
+   - websockets can multiplex vide data and control messages, in this example you can also get memory
+      stats / frame sizing from controller along with video stream
+   - WSocketServer can easily replicate stream to multiple connected clients
+      here in this example you can connect 2-3 clients simultaneously and get smooth stream (limited by wifi bandwidth)
+
+  Change you WiFi creds below, build and flash the code.
+  Connect to console to monitor for debug messages
+  Figure out IP of your board and access the board via web browser, watch for video stream
+*/
+
+#include <AsyncWSocket.h>
+#include <WiFi.h>
+#include "esp_camera.h"
+#include "mjpeg.h"
+
+
+#define WIFI_SSID "your_ssid"
+#define WIFI_PASSWD "your_pass"
+
+// AI-Thinker ESP32-CAM config - for more details see https://github.com/rzeldent/esp32cam-rtsp/ project
+camera_config_t cfg {
+  .pin_pwdn = 32,
+  .pin_reset = -1,
+  .pin_xclk = 0,
+
+  .pin_sscb_sda = 26,
+  .pin_sscb_scl = 27,
+
+  // Note: LED GPIO is apparently 4 not sure where that goes
+  // per https://github.com/donny681/ESP32_CAMERA_QR/blob/e4ef44549876457cd841f33a0892c82a71f35358/main/led.c
+  .pin_d7 = 35,
+  .pin_d6 = 34,
+  .pin_d5 = 39,
+  .pin_d4 = 36,
+  .pin_d3 = 21,
+  .pin_d2 = 19,
+  .pin_d1 = 18,
+  .pin_d0 = 5,
+  .pin_vsync = 25,
+  .pin_href = 23,
+  .pin_pclk = 22,
+  .xclk_freq_hz = 20000000,
+  .ledc_timer = LEDC_TIMER_1,
+  .ledc_channel = LEDC_CHANNEL_1,
+  .pixel_format = PIXFORMAT_JPEG,
+  // .frame_size = FRAMESIZE_UXGA, // needs 234K of framebuffer space
+  // .frame_size = FRAMESIZE_SXGA, // needs 160K for framebuffer
+  // .frame_size = FRAMESIZE_XGA, // needs 96K or even smaller FRAMESIZE_SVGA - can work if using only 1 fb
+  .frame_size = FRAMESIZE_SVGA,
+  .jpeg_quality = 15,               //0-63 lower numbers are higher quality
+  .fb_count = 2, // if more than one i2s runs in continous mode.  Use only with jpeg
+  .fb_location = CAMERA_FB_IN_PSRAM,
+  .grab_mode = CAMERA_GRAB_LATEST,
+  .sccb_i2c_port = 0
+};
+
+// camera frame buffer pointer
+camera_fb_t *fb{nullptr};
+
+// WS Event server callback declaration
+void wsEvent(WSocketClient *client, WSocketClient::event_t event);
+
+// Our WebServer
+AsyncWebServer server(80);
+// WSocket Server URL and callback function
+WSocketServer ws("/wsstream", wsEvent);
+// a unique steam id - it is used to avoid sending dublicate frames when multiple clients connected to stream
+uint32_t client_id{0};
+
+void sendFrame(uint32_t token){
+  if (client_id == 0){
+    // first client connected grabs the stream token
+    client_id = token;
+  } else if (token != client_id) {
+    // we will send next frame only upon delivery the previous one to client owning the token, others we ignore
+    // this is to avoid stacking frames clones in the Q when multiple clients are connected to the server
+    return;
+  }
+
+  //return the frame buffer back to the driver for reuse
+  esp_camera_fb_return(fb);
+  // get 2nd buffer from camera
+  fb = esp_camera_fb_get();
+
+  // generate metadata info frame
+  // this text frame contains memory stat and will be displayed along video stream
+  char buff[100];
+  snprintf(buff, 100, "FrameSize:%u, Mem:%lu, PSRAM:%lu", fb->len, ESP.getFreeHeap(), ESP.getFreePsram());
+  ws.textAll(buff);
+
+  // here we MUST ensure that client owning the stream is able to send data, otherwise recursion would crash controller
+  if (ws.clientState(client_id) == WSocketClient::err_t::ok){
+    /*    
+      for video frame sending we will use WSMessageStaticBlob object.
+      It can send large memory buffers directly to websocket peers without intermediate buffering and data copies
+      and it is the most efficient way to send static data
+    */
+    auto m = std::make_shared<WSMessageStaticBlob>(
+      WSFrameType_t::binary,    // binary message
+      true,                     // final message
+      reinterpret_cast<const char*>(fb->buf), fb->len, // buffer to transfer
+      // the key here to understand when frame buffer completes delivery - for this we set
+      // the callback back to ourself, so that when when frame delivery would be completed,
+      // this function is called again to obtain a new frame buffer from camera
+      [](WSMessageStatus_t s, uint32_t t){ sendFrame(t); }, // a callback executed on message delivery
+      client_id     // stream token
+    );
+    // replicate frame to ALL peers
+    ws.messageAll(m);
+  } else {
+    // current client can't receive stream (maybe he disconnected), we reset token here so that other client
+    // can reconnect and take the ownership of the stream
+    client_id = 0;
+  }
+
+  /*
+    Note! Though this example is able to send video stream to multiple clients simultaneously, it has one gap -
+    when same buffer is streamed to multiple peers and the 'owner' of stream completes transfer, others might
+    still be in-progress. The buffer pointer is switched to next one from camera only upon full delivery on
+    message object destruction. It does not allow pipelining and slower clients could affect the others.
+    The question of synchronization multiple clients is out of scope of this simple example. It's just a
+    demonstarion of working with WebSockets.
+  */
+}
+
+void wsEvent(WSocketClient *client, WSocketClient::event_t event){
+  switch (event){
+    // new client connected
+    case WSocketClient::event_t::connect : {
+      Serial.printf("Client id:%lu connected\n", client->id);
+      if (fb)
+        sendFrame(client->id);
+      else
+        ws.text(client->id, "Cam init failed!");
+      break;
+    }
+
+    // client diconnected
+    case WSocketClient::event_t::disconnect : {
+      Serial.printf("Client id:%lu disconnected\n", client->id);
+      if (client_id == client->id)
+      // reset stream token
+      client_id = 0;
+      break;
+    }
+
+    // any other events
+    default:;
+      // incoming messages could be used for controls or any other functionality
+      // not implemented in this example but should be considered
+      // If not discaded messages will overflow incoming Q
+      client->dequeueMessage();
+      break;
+  }
+}
+
+void setup() {
+  Serial.begin(115200);
+
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(WIFI_SSID, WIFI_PASSWD);
+
+  // Wait for connection
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(250);
+    Serial.print(".");
+  }
+  Serial.println();
+  Serial.print("Connected to ");
+  Serial.println(WIFI_SSID);
+  Serial.print("IP address: ");
+  Serial.println(WiFi.localIP());
+  Serial.println();
+  Serial.printf("to access VideoStream pls open http://%s/\n", WiFi.localIP().toString().c_str());
+
+  // init camera
+  esp_err_t err = esp_camera_init(&cfg);
+  if (err != ESP_OK)
+  {
+    Serial.printf("Camera probe failed with error 0x%x\n", err);
+  } else 
+    fb = esp_camera_fb_get();
+
+  // server serves index page
+  server.on("/", HTTP_GET, [](AsyncWebServerRequest *request) {
+    // need to cast to uint8_t*
+    // if you do not, the const char* will be copied in a temporary String buffer
+    request->send(200, "text/html", (uint8_t *)htmlPage, std::string_view(htmlPage).length());
+  });
+
+  // attach our WSocketServer
+  server.addHandler(&ws);
+  server.begin();
+}
+
+
+void loop() {
+  // nothing to do here at all
+  vTaskDelete(NULL);
+}

--- a/wsocket_examples/VideoStreaming/mjpeg.h
+++ b/wsocket_examples/VideoStreaming/mjpeg.h
@@ -1,0 +1,570 @@
+// this page provides minimalistic WebSocket MJPEG CAM streaming app
+// disclaimer: this page and code was generated with the help of DeepSeek AI tool
+
+static const char *htmlPage = R"(
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MJPEG WebSocket Stream</title>
+   <!-- disclaimer: this page and code was generated with the help of DeepSeek AI tool -->
+    <style>
+    * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+    }
+    
+    body {
+        font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        min-height: 100vh;
+        padding: 20px;
+    }
+    
+    .container {
+        max-width: 800px;
+        margin: 0 auto;
+        background: white;
+        border-radius: 15px;
+        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+        overflow: hidden;
+    }
+    
+    h1 {
+        background: linear-gradient(135deg, #2c3e50, #3498db);
+        color: white;
+        padding: 20px;
+        text-align: center;
+        font-size: 1.5em;
+    }
+    
+    .controls {
+        padding: 20px;
+        background: #f8f9fa;
+        border-bottom: 1px solid #e9ecef;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 15px;
+    }
+    
+    button {
+        padding: 10px 20px;
+        border: none;
+        border-radius: 5px;
+        cursor: pointer;
+        font-weight: bold;
+        transition: all 0.3s ease;
+    }
+    
+    #connectBtn {
+        background: #28a745;
+        color: white;
+    }
+    
+    #connectBtn:hover:not(:disabled) {
+        background: #218838;
+        transform: translateY(-2px);
+    }
+    
+    #disconnectBtn {
+        background: #dc3545;
+        color: white;
+    }
+    
+    #disconnectBtn:hover:not(:disabled) {
+        background: #c82333;
+        transform: translateY(-2px);
+    }
+    
+    button:disabled {
+        background: #6c757d;
+        cursor: not-allowed;
+        transform: none !important;
+    }
+    
+    .status {
+        font-weight: bold;
+    }
+    
+    #status {
+        padding: 5px 10px;
+        border-radius: 15px;
+        font-size: 0.9em;
+    }
+    
+    #status.connected {
+        background: #d4edda;
+        color: #155724;
+    }
+    
+    #status.disconnected {
+        background: #f8d7da;
+        color: #721c24;
+    }
+    
+    #status.connecting {
+        background: #fff3cd;
+        color: #856404;
+    }
+    
+    .video-container {
+        padding: 20px;
+        text-align: center;
+        background: #000;
+    }
+    
+    #videoCanvas {
+        border: 3px solid #34495e;
+        border-radius: 10px;
+        background: #000;
+        max-width: 100%;
+        height: auto;
+        box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
+    }
+    
+    .info {
+        padding: 15px;
+        background: #f8f9fa;
+        border-top: 1px solid #e9ecef;
+        display: flex;
+        justify-content: space-around;
+        flex-wrap: wrap;
+        gap: 20px;
+    }
+    
+    .info-item {
+        text-align: center;
+    }
+    
+    .info-item p {
+        margin: 5px 0;
+        font-weight: bold;
+        color: #495057;
+        font-size: 0.9em;
+    }
+    
+    .info-value {
+        font-family: 'Courier New', monospace;
+        background: #e9ecef;
+        padding: 2px 6px;
+        border-radius: 3px;
+        margin-left: 5px;
+    }
+    
+    @media (max-width: 600px) {
+        .controls {
+            flex-direction: column;
+            text-align: center;
+        }
+        
+        .container {
+            margin: 10px;
+        }
+        
+        #videoCanvas {
+            width: 100%;
+            height: auto;
+        }
+        
+        .info {
+            flex-direction: column;
+            gap: 10px;
+        }
+        
+        .info-item {
+            text-align: left;
+        }
+    }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>MJPEG WebSocket Video Stream</h1>
+        
+        <div class="controls">
+            <button id="connectBtn">Connect</button>
+            <button id="disconnectBtn" disabled>Disconnect</button>
+            <div class="status">
+                Status: <span id="status">Disconnected</span>
+            </div>
+        </div>
+
+        <div class="video-container">
+            <canvas id="videoCanvas" width="640" height="480"></canvas>
+        </div>
+
+        <div class="info">
+            <div class="info-item">
+                <p>FPS: <span id="fpsCounter">0</span></p>
+                <p>Frame Count: <span id="frameCounter">0</span></p>
+            </div>
+            <div class="info-item">
+                <p>Frame Size: <span id="frameSize">0</span> bytes</p>
+                <p>Memory: <span id="memory">0</span> bytes free</p>
+                <p>PSRAM: <span id="psram">0</span> bytes free</p>
+            </div>
+        </div>
+    </div>
+
+    <script>
+class MJPEGStreamPlayer {
+    constructor() {
+        this.ws = null;
+        this.canvas = document.getElementById('videoCanvas');
+        this.ctx = this.canvas.getContext('2d');
+        this.statusElement = document.getElementById('status');
+        this.fpsCounter = document.getElementById('fpsCounter');
+        this.frameCounterElement = document.getElementById('frameCounter');
+        
+        // Info display elements
+        this.frameSizeElement = document.getElementById('frameSize');
+        this.memoryElement = document.getElementById('memory');
+        this.psramElement = document.getElementById('psram');
+        
+        this.frameCount = 0;
+        this.lastFpsUpdate = 0;
+        this.framesThisSecond = 0;
+        this.currentFps = 0;
+        
+        // Frame info storage
+        this.lastFrameInfo = {
+            frameSize: 0,
+            memory: 0,
+            psram: 0,
+            lastUpdate: 0
+        };
+        
+        this.isPlaying = false;
+        this.pendingFrames = 0;
+        this.maxPendingFrames = 2; // Limit concurrent frame processing
+        
+        this.initializeEventListeners();
+        this.updateFpsCounter();
+    }
+
+    initializeEventListeners() {
+        document.getElementById('connectBtn').addEventListener('click', () => this.connect());
+        document.getElementById('disconnectBtn').addEventListener('click', () => this.disconnect());
+    }
+
+    connect() {
+        this.updateStatus('connecting', 'Connecting...');
+        
+        try {
+            this.ws = new WebSocket('ws://' + location.host + '/wsstream');
+            
+            this.ws.binaryType = 'arraybuffer';
+            
+            this.ws.onopen = () => {
+                this.updateStatus('connected', 'Connected');
+                this.toggleButtons(true);
+                this.isPlaying = true;
+                this.pendingFrames = 0;
+                console.log('WebSocket connected');
+            };
+            
+            this.ws.onmessage = (event) => {
+                if (event.data instanceof ArrayBuffer) {
+                    // Binary message - MJPEG frame
+                    this.processFrame(event.data);
+                } else if (typeof event.data === 'string') {
+                    // Text message - frame information
+                    this.processInfoMessage(event.data);
+                }
+            };
+            
+            this.ws.onclose = (event) => {
+                this.updateStatus('disconnected', 'Disconnected');
+                this.toggleButtons(false);
+                this.isPlaying = false;
+                console.log('WebSocket disconnected:', event.code, event.reason);
+/*
+                // Attempt reconnect if not manually disconnected
+                if (event.code !== 1000) { // 1000 = normal closure
+                    console.log('Attempting to reconnect in 2 seconds...');
+                    setTimeout(() => {
+                        if (!this.ws || this.ws.readyState === WebSocket.CLOSED) {
+                            this.connect();
+                        }
+                    }, 2000);
+                }
+*/
+            };
+            
+            this.ws.onerror = (error) => {
+                console.error('WebSocket error:', error);
+                // Note: onclose will be called after onerror
+            };
+            
+        } catch (error) {
+            console.error('Failed to connect:', error);
+            this.updateStatus('disconnected', 'Connection Failed');
+        }
+    }
+
+    disconnect() {
+        this.isPlaying = false;
+        if (this.ws) {
+            // Use normal closure code
+            this.ws.close(1000, 'User disconnected');
+            this.ws = null;
+        }
+        this.clearCanvas();
+    }
+
+    processFrame(arrayBuffer) {
+        if (!this.isPlaying || this.pendingFrames >= this.maxPendingFrames) {
+            // Skip frame if not playing or too many pending frames
+            return;
+        }
+
+        this.pendingFrames++;
+        
+        try {
+            // Create blob and process frame
+            const blob = new Blob([arrayBuffer], { type: 'image/jpeg' });
+            const url = URL.createObjectURL(blob);
+            
+            const img = new Image();
+            
+            img.onload = () => {
+                this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+                this.ctx.drawImage(img, 0, 0, this.canvas.width, this.canvas.height);
+                URL.revokeObjectURL(url);
+                this.updateCounters();
+                this.updateFrameInfoDisplay();
+                this.pendingFrames--;
+            };
+            
+            img.onerror = (error) => {
+                console.error('Failed to load image frame:', error);
+                URL.revokeObjectURL(url);
+                this.pendingFrames--;
+            };
+            
+            // Start loading the image
+            img.src = url;
+            
+        } catch (error) {
+            console.error('Error processing frame:', error);
+            this.pendingFrames--;
+        }
+    }
+
+    processInfoMessage(message) {
+        console.log('Received info message:', message.trim());
+        
+        try {
+            // Parse the info message format: "FrameSize:%u, Mem:%u, psram:%u\n"
+            const frameSizeMatch = message.match(/FrameSize:\s*(\d+)/);
+            const memoryMatch = message.match(/Mem:\s*(\d+)/);
+            const psramMatch = message.match(/PSRAM:\s*(\d+)/);
+            
+            if (frameSizeMatch || memoryMatch || psramMatch) {
+                this.lastFrameInfo = {
+                    frameSize: frameSizeMatch ? parseInt(frameSizeMatch[1]) : this.lastFrameInfo.frameSize,
+                    memory: memoryMatch ? parseInt(memoryMatch[1]) : this.lastFrameInfo.memory,
+                    psram: psramMatch ? parseInt(psramMatch[1]) : this.lastFrameInfo.psram,
+                    lastUpdate: Date.now()
+                };
+                
+                this.updateFrameInfoDisplay();
+            } else {
+                console.warn('Unknown info message format:', message.trim());
+            }
+        } catch (error) {
+            console.error('Error parsing info message:', error, message);
+        }
+    }
+
+    updateFrameInfoDisplay() {
+        try {
+            // Format and display the frame information
+            this.frameSizeElement.textContent = this.formatBytes(this.lastFrameInfo.frameSize);
+            this.memoryElement.textContent = this.formatBytes(this.lastFrameInfo.memory);
+            this.psramElement.textContent = this.formatBytes(this.lastFrameInfo.psram);
+            
+            // Add timestamp indicator if info is stale (older than 5 seconds)
+            const now = Date.now();
+            const isStale = (now - this.lastFrameInfo.lastUpdate) > 5000;
+            
+            const elements = [this.frameSizeElement, this.memoryElement, this.psramElement];
+            elements.forEach(element => {
+                if (isStale && this.lastFrameInfo.lastUpdate > 0) {
+                    element.style.color = '#6c757d';
+                    element.style.fontStyle = 'italic';
+                    element.title = 'Info may be outdated (last update: ' + 
+                        new Date(this.lastFrameInfo.lastUpdate).toLocaleTimeString() + ')';
+                } else {
+                    element.style.color = '';
+                    element.style.fontStyle = '';
+                    element.title = 'Last update: ' + 
+                        new Date(this.lastFrameInfo.lastUpdate).toLocaleTimeString();
+                }
+            });
+        } catch (error) {
+            console.error('Error updating frame info display:', error);
+        }
+    }
+
+    formatBytes(bytes) {
+        if (bytes === 0 || isNaN(bytes)) return '0 B';
+        
+        const k = 1024;
+        const sizes = ['B', 'KB', 'MB', 'GB'];
+        const i = Math.floor(Math.log(bytes) / Math.log(k));
+        
+        return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+    }
+
+    updateCounters() {
+        this.frameCount++;
+        this.frameCounterElement.textContent = this.frameCount;
+        
+        // Calculate FPS
+        const now = performance.now();
+        if (now >= this.lastFpsUpdate + 1000) {
+            this.currentFps = this.framesThisSecond;
+            this.framesThisSecond = 0;
+            this.lastFpsUpdate = now;
+        }
+        this.framesThisSecond++;
+    }
+
+    updateFpsCounter() {
+        this.fpsCounter.textContent = this.currentFps;
+        requestAnimationFrame(() => this.updateFpsCounter());
+    }
+
+    clearCanvas() {
+        try {
+            this.ctx.fillStyle = 'black';
+            this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
+            this.ctx.fillStyle = 'white';
+            this.ctx.font = '20px Arial';
+            this.ctx.textAlign = 'center';
+            this.ctx.fillText('Stream Disconnected', this.canvas.width / 2, this.canvas.height / 2);
+            
+            // Reset info display
+            this.frameSizeElement.textContent = '0 B';
+            this.memoryElement.textContent = '0 B';
+            this.psramElement.textContent = '0 B';
+            this.frameCount = 0;
+            this.frameCounterElement.textContent = '0';
+            this.currentFps = 0;
+        } catch (error) {
+            console.error('Error clearing canvas:', error);
+        }
+    }
+
+    updateStatus(className, text) {
+        this.statusElement.className = className;
+        this.statusElement.textContent = text;
+    }
+
+    toggleButtons(connected) {
+        document.getElementById('connectBtn').disabled = connected;
+        document.getElementById('disconnectBtn').disabled = !connected;
+    }
+}
+
+// Alternative method using createImageBitmap for better performance
+class MJPEGStreamPlayerOptimized extends MJPEGStreamPlayer {
+    processFrame(arrayBuffer) {
+        if (!this.isPlaying || this.pendingFrames >= this.maxPendingFrames) {
+            return;
+        }
+
+        this.pendingFrames++;
+        
+        try {
+            createImageBitmap(new Blob([arrayBuffer], { type: 'image/jpeg' }))
+                .then(bitmap => {
+                    if (this.isPlaying) {
+                        this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+                        this.ctx.drawImage(bitmap, 0, 0, this.canvas.width, this.canvas.height);
+                        this.updateCounters();
+                        this.updateFrameInfoDisplay();
+                    }
+                    this.pendingFrames--;
+                })
+                .catch(error => {
+                    console.error('Failed to decode image frame:', error);
+                    this.pendingFrames--;
+                    
+                    // Fallback to regular image loading
+                    this.fallbackProcessFrame(arrayBuffer);
+                });
+        } catch (error) {
+            console.error('Error in optimized frame processing:', error);
+            this.pendingFrames--;
+            this.fallbackProcessFrame(arrayBuffer);
+        }
+    }
+
+    fallbackProcessFrame(arrayBuffer) {
+        try {
+            const blob = new Blob([arrayBuffer], { type: 'image/jpeg' });
+            const url = URL.createObjectURL(blob);
+            
+            const img = new Image();
+            img.onload = () => {
+                this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+                this.ctx.drawImage(img, 0, 0, this.canvas.width, this.canvas.height);
+                URL.revokeObjectURL(url);
+                this.updateCounters();
+                this.updateFrameInfoDisplay();
+            };
+            img.onerror = () => {
+                URL.revokeObjectURL(url);
+            };
+            img.src = url;
+        } catch (error) {
+            console.error('Error in fallback frame processing:', error);
+        }
+    }
+}
+
+// Initialize the player when the page loads
+document.addEventListener('DOMContentLoaded', () => {
+    // Use optimized version if createImageBitmap is supported
+    if (typeof createImageBitmap === 'function') {
+        window.mjpegPlayer = new MJPEGStreamPlayerOptimized();
+    } else {
+        window.mjpegPlayer = new MJPEGStreamPlayer();
+    }
+});
+
+// Handle page visibility changes to pause/resume rendering
+document.addEventListener('visibilitychange', () => {
+    const player = window.mjpegPlayer;
+    if (player) {
+        player.isPlaying = !document.hidden;
+        if (document.hidden) {
+            // Clear canvas when page is hidden to save resources
+            player.ctx.clearRect(0, 0, player.canvas.width, player.canvas.height);
+            player.ctx.fillStyle = 'black';
+            player.ctx.fillRect(0, 0, player.canvas.width, player.canvas.height);
+            player.ctx.fillStyle = 'gray';
+            player.ctx.font = '16px Arial';
+            player.ctx.textAlign = 'center';
+            player.ctx.fillText('Page is hidden - video paused', player.canvas.width / 2, player.canvas.height / 2);
+        }
+    }
+});
+
+// Handle page beforeunload to properly close connection
+window.addEventListener('beforeunload', () => {
+    const player = window.mjpegPlayer;
+    if (player && player.ws) {
+        player.ws.close(1000, 'Page unloading');
+    }
+});
+    </script>
+</body>
+</html>
+)";

--- a/wsocket_examples/WebChat/WebChat.ino
+++ b/wsocket_examples/WebChat/WebChat.ino
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright 2016-2025 Hristo Gochkov, Mathieu Carbou, Emil Muratov
+
+//
+// A simple WebChat room working over WebSockets
+//
+
+/*
+  This example would show how WSocketServer could register connections/disconnections for every new user,
+  deliver messages to all connected user and replicate incoming data amoung all members of chat room.
+  Change you WiFi creds below, build and flash the code.
+  Connect to console to monitor debug messages.
+  Figure out IP of your board and access the board via web browser using two or more different devices,
+  Chat with yourself, have fun :)
+*/
+
+#include <AsyncWSocket.h>
+#include <WiFi.h>
+#include "html.h"
+
+#define WIFI_SSID "YourSSID"
+#define WIFI_PASSWD "YourPasswd"
+
+// WS Event server callback declaration
+void wsEvent(WSocketClient *client, WSocketClient::event_t event);
+
+// Our WebServer
+AsyncWebServer server(80);
+// WSocket Server URL and callback function
+WSocketServer ws("/chat", wsEvent);
+
+void wsEvent(WSocketClient *client, WSocketClient::event_t event){
+  switch (event){
+    // new client connected
+    case WSocketClient::event_t::connect : {
+      Serial.printf("Client id:%u connected\n", client->id);
+      char buff[100];
+      snprintf(buff, 100, "WServer: Hello user, your id is:%u, there are %u members on-line, pls be polite here!", client->id, ws.activeClientsCount());
+      // greet new user personally
+      ws.text(client->id, buff);
+      snprintf(buff, 100, "WServer:  New client with id:%u joined the room", client->id);
+      // Announce new user entered the room
+      ws.textAll(client->id, buff);
+      break;
+    }
+
+    // client diconnected
+    case WSocketClient::event_t::disconnect : {
+      Serial.printf("Client id:%u disconnected\n", client->id);
+      char buff[100];
+      snprintf(buff, 100, "WServer: Client with id:%u left the room, %u members on-line", client->id, ws.activeClientsCount());
+      ws.textAll(client->id, buff);
+      break;
+    }
+
+    // new messages from clients
+    case WSocketClient::event_t::msgRecv :
+      // any incoming messages we must deQ and discard,
+      // there is no need to resend it back to, it's handled on the server side.
+      // If not discaded messages will overflow incoming Q
+      client->dequeueMessage();
+      break;
+
+    default:;
+  }
+}
+
+
+void setup() {
+  Serial.begin(115200);
+
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(WIFI_SSID, WIFI_PASSWD);
+
+  // Wait for connection
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(250);
+    Serial.print(".");
+  }
+  Serial.println();
+  Serial.println("Connected to WIFI_SSID");
+  Serial.print("IP address: ");
+  Serial.println(WiFi.localIP());
+  Serial.println();
+  Serial.printf("to access WebChat pls open http://%s/\n", WiFi.localIP().toString().c_str());
+
+  server.on("/", HTTP_GET, [](AsyncWebServerRequest *request) {
+    // need to cast to uint8_t*
+    // if you do not, the const char* will be copied in a temporary String buffer
+    request->send(200, "text/html", (uint8_t *)htmlChatPage, strlen(htmlChatPage));
+  });
+
+  // keep TCP/WS connection open
+  ws.setKeepAlive(20);
+
+  /*
+    Enable server echo to reflect incoming messages to all participans of the current chat room
+  */
+  ws.setServerEcho(true, true); // 2nd 'true' here is 'SplitHorizon' - server will reflect all message to every peer except the one where it came from
+
+  server.addHandler(&ws);
+
+  server.begin();
+}
+
+
+void loop() {
+  // nothing to do here
+  delay(100);
+}

--- a/wsocket_examples/WebChat/html.h
+++ b/wsocket_examples/WebChat/html.h
@@ -1,0 +1,249 @@
+// this page provides minimalistic WebChat room
+// disclaimer: this page and code was generated with the help of AI tools
+
+static const char *htmlChatPage = R"(
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>AsyncWebSocket Chat example</title>
+  <!-- disclaimer: this page and code was generated with the help of AI tools -->
+  <style>
+    body {
+      margin: 0;
+      font-family: Arial, sans-serif;
+      background-color: #121212;
+      color: #ffffff;
+      display: flex;
+      flex-direction: column;
+      height: 100vh;
+    }
+
+    #messages {
+      flex: 1;
+      overflow-y: auto;
+      padding: 20px;
+      box-sizing: border-box;
+      border-bottom: 1px solid #333;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .message {
+      max-width: 70%;
+      margin-bottom: 10px;
+      padding: 10px 14px;
+      border-radius: 18px;
+      line-height: 1.4;
+      word-wrap: break-word;
+      white-space: pre-wrap;
+    }
+
+    .sender {
+      align-self: flex-end;
+      background-color: #3f51b5;
+      color: white;
+      border-bottom-right-radius: 0;
+    }
+
+    .receiver {
+      align-self: flex-start;
+      background-color: #2a2a2a;
+      color: #ffffff;
+      border-bottom-left-radius: 0;
+    }
+
+    #inputArea {
+      display: flex;
+      padding: 10px 20px;
+      box-sizing: border-box;
+      background-color: #1e1e1e;
+    }
+
+    #replyInput {
+      flex: 1;
+      padding: 10px;
+      border: none;
+      border-radius: 4px;
+      font-size: 14px;
+      background-color: #2a2a2a;
+      color: #fff;
+    }
+
+    #sendButton {
+      margin-left: 10px;
+      padding: 10px 16px;
+      background-color: #3f51b5;
+      color: white;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 14px;
+    }
+
+    #sendButton:hover {
+      background-color: #5c6bc0;
+    }
+
+    /* Modal Styles */
+    #usernameModal {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100vw;
+      height: 100vh;
+      background-color: rgba(0,0,0,0.8);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 9999;
+    }
+
+    #usernameModalContent {
+      background-color: #1e1e1e;
+      padding: 30px;
+      border-radius: 8px;
+      text-align: center;
+      box-shadow: 0 0 10px rgba(0,0,0,0.5);
+    }
+
+    #usernameInput {
+      padding: 10px;
+      width: 100%;
+      max-width: 300px;
+      font-size: 16px;
+      border: none;
+      border-radius: 4px;
+      margin-top: 10px;
+      background-color: #2a2a2a;
+      color: white;
+    }
+
+    #usernameSubmit {
+      margin-top: 15px;
+      padding: 10px 20px;
+      font-size: 14px;
+      background-color: #3f51b5;
+      color: white;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+
+    #usernameSubmit:hover {
+      background-color: #5c6bc0;
+    }
+  </style>
+</head>
+<body>
+  <!-- Username Modal -->
+  <div id="usernameModal">
+    <div id="usernameModalContent">
+      <h2>Enter your username</h2>
+      <input type="text" id="usernameInput" placeholder="Your name" />
+      <br />
+      <button id="usernameSubmit">Start Chat</button>
+    </div>
+  </div>
+
+  <!-- Chat Messages -->
+  <div id="messages"></div>
+
+  <!-- Input Field -->
+  <div id="inputArea">
+    <input type="text" id="replyInput" placeholder="Type your message..." disabled />
+    <button id="sendButton" disabled>Send</button>
+  </div>
+
+  <script>
+    let username = '';
+    const socket = new WebSocket('ws://' + location.host + '/chat'); // Replace with your WebSocket server
+
+    const messagesDiv = document.getElementById('messages');
+    const replyInput = document.getElementById('replyInput');
+    const sendButton = document.getElementById('sendButton');
+
+    const usernameModal = document.getElementById('usernameModal');
+    const usernameInput = document.getElementById('usernameInput');
+    const usernameSubmit = document.getElementById('usernameSubmit');
+
+    // Modal submission
+    usernameSubmit.addEventListener('click', submitUsername);
+    usernameInput.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') submitUsername();
+    });
+
+    function submitUsername() {
+      const name = usernameInput.value.trim();
+      if (name !== '') {
+        username = name;
+        usernameModal.style.display = 'none';
+        replyInput.disabled = false;
+        sendButton.disabled = false;
+        replyInput.focus();
+      }
+    }
+
+    socket.addEventListener('open', () => {
+      console.log('WebSocket connection opened');
+    });
+
+    socket.addEventListener('message', (event) => {
+        console.log('msg in:', event.data);
+        // If the server echoes back the same message we sent, ignore it
+        if (event.data.startsWith(`${username}:`)) {
+            return;
+        }
+      const { user, message } = parseMessage(event.data);
+      appendMessage(user, message, 'receiver');
+    });
+
+    sendButton.addEventListener('click', sendMessage);
+    replyInput.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter') {
+        sendMessage();
+      }
+    });
+
+    function sendMessage() {
+      const message = replyInput.value.trim();
+      if (message !== '' && socket.readyState === WebSocket.OPEN) {
+        const fullMessage = `${username}: ${message}`;
+        console.log('msg out:', fullMessage);
+        socket.send(fullMessage);
+        appendMessage(username, message, 'sender');
+        replyInput.value = '';
+      }
+    }
+
+    function appendMessage(user, message, type) {
+      const msg = document.createElement('div');
+      msg.className = `message ${type}`;
+      msg.innerHTML = `<strong>${escapeHtml(user)}:</strong> ${escapeHtml(message)}`;
+      messagesDiv.appendChild(msg);
+      messagesDiv.scrollTop = messagesDiv.scrollHeight;
+    }
+
+    // Parse message as "Username: Message text"
+    function parseMessage(raw) {
+      const colonIndex = raw.indexOf(':');
+      if (colonIndex > 0) {
+        const user = raw.slice(0, colonIndex).trim();
+        const message = raw.slice(colonIndex + 1).trim();
+        return { user, message };
+      } else {
+        return { user: 'Server', message: raw };
+      }
+    }
+
+    // Prevent XSS in messages
+    function escapeHtml(text) {
+      const div = document.createElement("div");
+      div.innerText = text;
+      return div.innerHTML;
+    }
+  </script>
+</body>
+</html>
+)";


### PR DESCRIPTION
Hey team, long time! family matters, you know...
but I've returned with something new. Took my time to re-implement websockets from scratch.
 - created a newer more abstracted design pattern for message containers, gives more freedom to accommodate various objects
 - incoming message reassembly that spans multiple TCP packets
 - queue/message size limit with graceful disconnection 
 - server side message replication
 - multiple endpoint handling with one server instance
 - optional server worker that decouples user callbacks handling from AsyncTCP (yes, finally!)
 - some other things...

I decided to give away all backward compatibility to untie my hands and implemented all in a separate classes within a single `.cpp` unit, ESP32/C++17 minimum, other platforms I do not have in possession for now.

This all is highly experimental for now, still work in progress with a bunch of features to be implemented. But I've created some examples for evaluation and early feedback if any (esp32cam is most funny one to play with).