### PR TITLE
Correctly support ESP8266 for examples and default filters

### DIFF
--- a/examples/AsyncResponseStream/AsyncResponseStream.ino
+++ b/examples/AsyncResponseStream/AsyncResponseStream.ino
@@ -20,7 +20,7 @@ static AsyncWebServer server(80);
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/AsyncTunnel/AsyncTunnel.ino
+++ b/examples/AsyncTunnel/AsyncTunnel.ino
@@ -70,7 +70,7 @@ static const size_t htmlContentLength = strlen_P(htmlContent);
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
   while (WiFi.status() != WL_CONNECTED) {
     delay(500);

--- a/examples/Auth/Auth.ino
+++ b/examples/Auth/Auth.ino
@@ -58,7 +58,7 @@ static AsyncAuthorizationMiddleware authz([](AsyncWebServerRequest *request) {
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/CORS/CORS.ino
+++ b/examples/CORS/CORS.ino
@@ -25,7 +25,7 @@ static AsyncCorsMiddleware cors;
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/CaptivePortal/CaptivePortal.ino
+++ b/examples/CaptivePortal/CaptivePortal.ino
@@ -28,7 +28,7 @@ public:
     response->print("<!DOCTYPE html><html><head><title>Captive Portal</title></head><body>");
     response->print("<p>This is our captive portal front page.</p>");
     response->printf("<p>You were trying to reach: http://%s%s</p>", request->host().c_str(), request->url().c_str());
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
     response->printf("<p>Try opening <a href='http://%s'>this link</a> instead</p>", WiFi.softAPIP().toString().c_str());
 #endif
     response->print("</body></html>");
@@ -41,7 +41,7 @@ void setup() {
   Serial.println();
   Serial.println("Configuring access point...");
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   if (!WiFi.softAP("esp-captive")) {
     Serial.println("Soft AP creation failed.");
     while (1);

--- a/examples/CatchAllHandler/CatchAllHandler.ino
+++ b/examples/CatchAllHandler/CatchAllHandler.ino
@@ -86,7 +86,7 @@ static const size_t htmlContentLength = strlen_P(htmlContent);
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/ChunkResponse/ChunkResponse.ino
+++ b/examples/ChunkResponse/ChunkResponse.ino
@@ -86,7 +86,7 @@ static const size_t htmlContentLength = strlen_P(htmlContent);
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/ChunkRetryResponse/ChunkRetryResponse.ino
+++ b/examples/ChunkRetryResponse/ChunkRetryResponse.ino
@@ -90,7 +90,7 @@ static int key = -1;
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/EndBegin/EndBegin.ino
+++ b/examples/EndBegin/EndBegin.ino
@@ -24,7 +24,7 @@ static AsyncWebServer server(80);
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/Filters/Filters.ino
+++ b/examples/Filters/Filters.ino
@@ -32,7 +32,7 @@ public:
     response->print("<!DOCTYPE html><html><head><title>Captive Portal</title></head><body>");
     response->print("<p>This is out captive portal front page.</p>");
     response->printf("<p>You were trying to reach: http://%s%s</p>", request->host().c_str(), request->url().c_str());
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
     response->printf("<p>Try opening <a href='http://%s'>this link</a> instead</p>", WiFi.softAPIP().toString().c_str());
 #endif
     response->print("</body></html>");
@@ -51,17 +51,17 @@ void setup() {
       "/", HTTP_GET,
       [](AsyncWebServerRequest *request) {
         Serial.println("Captive portal request...");
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
         Serial.println("WiFi.localIP(): " + WiFi.localIP().toString());
 #endif
         Serial.println("request->client()->localIP(): " + request->client()->localIP().toString());
 #if ESP_IDF_VERSION_MAJOR >= 5
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
         Serial.println("WiFi.type(): " + String((int)WiFi.localIP().type()));
 #endif
         Serial.println("request->client()->type(): " + String((int)request->client()->localIP().type()));
 #endif
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
         Serial.println(WiFi.localIP() == request->client()->localIP() ? "should be: ON_STA_FILTER" : "should be: ON_AP_FILTER");
         Serial.println(WiFi.localIP() == request->client()->localIP());
         Serial.println(WiFi.localIP().toString() == request->client()->localIP().toString());
@@ -77,17 +77,17 @@ void setup() {
       "/", HTTP_GET,
       [](AsyncWebServerRequest *request) {
         Serial.println("Website request...");
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
         Serial.println("WiFi.localIP(): " + WiFi.localIP().toString());
 #endif
         Serial.println("request->client()->localIP(): " + request->client()->localIP().toString());
 #if ESP_IDF_VERSION_MAJOR >= 5
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
         Serial.println("WiFi.type(): " + String((int)WiFi.localIP().type()));
 #endif
         Serial.println("request->client()->type(): " + String((int)request->client()->localIP().type()));
 #endif
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
         Serial.println(WiFi.localIP() == request->client()->localIP() ? "should be: ON_STA_FILTER" : "should be: ON_AP_FILTER");
         Serial.println(WiFi.localIP() == request->client()->localIP());
         Serial.println(WiFi.localIP().toString() == request->client()->localIP().toString());
@@ -113,7 +113,7 @@ void setup() {
   // dnsServer.stop();
   // WiFi.softAPdisconnect();
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.persistent(false);
   WiFi.begin("IoT");
   while (WiFi.status() != WL_CONNECTED) {

--- a/examples/FlashResponse/FlashResponse.ino
+++ b/examples/FlashResponse/FlashResponse.ino
@@ -86,7 +86,7 @@ static const size_t htmlContentLength = strlen_P(htmlContent);
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/HeaderManipulation/HeaderManipulation.ino
+++ b/examples/HeaderManipulation/HeaderManipulation.ino
@@ -33,7 +33,7 @@ AsyncHeaderFreeMiddleware headerFree;
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/Headers/Headers.ino
+++ b/examples/Headers/Headers.ino
@@ -24,7 +24,7 @@ static AsyncWebServer server(80);
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/Json/Json.ino
+++ b/examples/Json/Json.ino
@@ -28,7 +28,7 @@ static AsyncCallbackJsonWebHandler *handler = new AsyncCallbackJsonWebHandler("/
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/LargeResponse/LargeResponse.ino
+++ b/examples/LargeResponse/LargeResponse.ino
@@ -126,7 +126,7 @@ private:
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/Logging/Logging.ino
+++ b/examples/Logging/Logging.ino
@@ -25,7 +25,7 @@ static AsyncLoggingMiddleware requestLogger;
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/MessagePack/MessagePack.ino
+++ b/examples/MessagePack/MessagePack.ino
@@ -28,7 +28,7 @@ static AsyncCallbackJsonWebHandler *handler = new AsyncCallbackJsonWebHandler("/
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/Middleware/Middleware.ino
+++ b/examples/Middleware/Middleware.ino
@@ -34,7 +34,7 @@ public:
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/Params/Params.ino
+++ b/examples/Params/Params.ino
@@ -74,7 +74,7 @@ static const size_t htmlContentLength = strlen_P(htmlContent);
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/PartitionDownloader/PartitionDownloader.ino
+++ b/examples/PartitionDownloader/PartitionDownloader.ino
@@ -34,7 +34,7 @@ static AsyncWebServer server(80);
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/PerfTests/PerfTests.ino
+++ b/examples/PerfTests/PerfTests.ino
@@ -91,7 +91,7 @@ static volatile size_t requests = 0;
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/RateLimit/RateLimit.ino
+++ b/examples/RateLimit/RateLimit.ino
@@ -25,7 +25,7 @@ static AsyncRateLimitMiddleware rateLimit;
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/Redirect/Redirect.ino
+++ b/examples/Redirect/Redirect.ino
@@ -24,7 +24,7 @@ static AsyncWebServer server(80);
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/RequestContinuation/RequestContinuation.ino
+++ b/examples/RequestContinuation/RequestContinuation.ino
@@ -34,7 +34,7 @@ static AsyncWebServerRequestPtr gpioRequest;
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/RequestContinuationComplete/RequestContinuationComplete.ino
+++ b/examples/RequestContinuationComplete/RequestContinuationComplete.ino
@@ -94,7 +94,7 @@ static bool processLongRunningOperation(LongRunningOperation *op) {
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/ResumableDownload/ResumableDownload.ino
+++ b/examples/ResumableDownload/ResumableDownload.ino
@@ -24,7 +24,7 @@ static AsyncWebServer server(80);
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/Rewrite/Rewrite.ino
+++ b/examples/Rewrite/Rewrite.ino
@@ -24,7 +24,7 @@ static AsyncWebServer server(80);
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/ServerSentEvents/ServerSentEvents.ino
+++ b/examples/ServerSentEvents/ServerSentEvents.ino
@@ -58,7 +58,7 @@ static AsyncEventSource events("/events");
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/ServerSentEvents_PR156/ServerSentEvents_PR156.ino
+++ b/examples/ServerSentEvents_PR156/ServerSentEvents_PR156.ino
@@ -64,7 +64,7 @@ static constexpr uint32_t timeoutClose = 15000;
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/ServerState/ServerState.ino
+++ b/examples/ServerState/ServerState.ino
@@ -25,7 +25,7 @@ static AsyncWebServer server2(80);
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/SkipServerMiddleware/SkipServerMiddleware.ino
+++ b/examples/SkipServerMiddleware/SkipServerMiddleware.ino
@@ -27,7 +27,7 @@ static AsyncLoggingMiddleware logging;
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/SlowChunkResponse/SlowChunkResponse.ino
+++ b/examples/SlowChunkResponse/SlowChunkResponse.ino
@@ -89,7 +89,7 @@ static size_t charactersIndex = 0;
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/StaticFile/StaticFile.ino
+++ b/examples/StaticFile/StaticFile.ino
@@ -111,7 +111,7 @@ static const size_t index2_html_gz_len = sizeof(index2_html_gz);
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/Templates/Templates.ino
+++ b/examples/Templates/Templates.ino
@@ -49,7 +49,7 @@ static void setUptimeInMinutes(unsigned t) {
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/URIMatcher/URIMatcher.ino
+++ b/examples/URIMatcher/URIMatcher.ino
@@ -44,7 +44,7 @@ void setup() {
   Serial.println();
   Serial.println("=== AsyncURIMatcher Example ===");
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
   Serial.print("AP IP address: ");

--- a/examples/URIMatcherTest/URIMatcherTest.ino
+++ b/examples/URIMatcherTest/URIMatcherTest.ino
@@ -26,7 +26,7 @@ AsyncWebServer server(80);
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/Upload/Upload.ino
+++ b/examples/Upload/Upload.ino
@@ -31,7 +31,7 @@ void setup() {
     LittleFS.begin();
   }
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/UploadFlash/UploadFlash.ino
+++ b/examples/UploadFlash/UploadFlash.ino
@@ -36,7 +36,7 @@ void setup() {
     LittleFS.begin();
   }
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/WebSocket/WebSocket.ino
+++ b/examples/WebSocket/WebSocket.ino
@@ -25,7 +25,7 @@ static AsyncWebSocket ws("/ws");
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/examples/WebSocketEasy/WebSocketEasy.ino
+++ b/examples/WebSocketEasy/WebSocketEasy.ino
@@ -71,7 +71,7 @@ static const size_t htmlContentLength = strlen_P(htmlContent);
 void setup() {
   Serial.begin(115200);
 
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
   WiFi.softAP("esp-captive");
 #endif

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -62,6 +62,12 @@
 #define ASYNCWEBSERVER_USE_CHUNK_INFLIGHT 1
 #endif
 
+#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED || defined(ESP8266)
+#define ASYNCWEBSERVER_WIFI_SUPPORTED 1
+#else
+#define ASYNCWEBSERVER_WIFI_SUPPORTED 0
+#endif
+
 class AsyncWebServer;
 class AsyncWebServerRequest;
 class AsyncWebServerResponse;

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -18,7 +18,7 @@
 using namespace asyncsrv;
 
 bool ON_STA_FILTER(AsyncWebServerRequest *request) {
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   return WiFi.localIP() == request->client()->localIP();
 #else
   return false;
@@ -26,7 +26,7 @@ bool ON_STA_FILTER(AsyncWebServerRequest *request) {
 }
 
 bool ON_AP_FILTER(AsyncWebServerRequest *request) {
-#if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED || LT_ARD_HAS_WIFI || CONFIG_ESP32_WIFI_ENABLED
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
   return WiFi.localIP() != request->client()->localIP();
 #else
   return false;


### PR DESCRIPTION
This PR allows to run examples on esp8266 (WiFi was not activated).

It also corrects the default filters ON_STA_FILTER and ON_AP_FILTER