### PR TITLE
Support ESP8266 TCP stack config

### DIFF
--- a/src/WebResponseImpl.h
+++ b/src/WebResponseImpl.h
@@ -16,8 +16,12 @@
 #include "./literals.h"
 
 #ifndef CONFIG_LWIP_TCP_MSS
+#ifdef TCP_MSS  // ESP8266
+#define CONFIG_LWIP_TCP_MSS TCP_MSS
+#else
 // as it is defined for ESP32's Arduino LWIP
 #define CONFIG_LWIP_TCP_MSS 1436
+#endif
 #endif
 
 #define ASYNC_RESPONCE_BUFF_SIZE CONFIG_LWIP_TCP_MSS * 2

--- a/src/WebResponses.cpp
+++ b/src/WebResponses.cpp
@@ -10,8 +10,12 @@
 #include <utility>
 
 #ifndef CONFIG_LWIP_TCP_WND_DEFAULT
+#ifdef TCP_WND  // ESP8266
+#define CONFIG_LWIP_TCP_WND_DEFAULT TCP_WND
+#else
 // as it is defined for esp32's LWIP
 #define CONFIG_LWIP_TCP_WND_DEFAULT 5760
+#endif
 #endif
 
 using namespace asyncsrv;


### PR DESCRIPTION
Use the ESP8266 network stack configuration values if they are present and the ESP32 defines are missing.

Fixes #343