### PR TITLE
Deal with safari fragmented pong data

### DIFF
--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -518,9 +518,12 @@ void AsyncWebSocketClient::_onData(void *pbuf, size_t plen) {
       _pinfo.masked = ((fdata[1] & 0x80) != 0) ? 1 : 0;
       _pinfo.len = fdata[1] & 0x7F;
 
-      // async_ws_log_d("WS[%" PRIu32 "]: _onData: %" PRIu32, _clientId, plen);
-      // async_ws_log_d("WS[%" PRIu32 "]: _status = %" PRIu32, _clientId, _status);
-      // async_ws_log_d("WS[%" PRIu32 "]: _pinfo: index: %" PRIu64 ", final: %" PRIu8 ", opcode: %" PRIu8 ", masked: %" PRIu8 ", len: %" PRIu64, _clientId, _pinfo.index, _pinfo.final, _pinfo.opcode, _pinfo.masked, _pinfo.len);
+      // async_ws_log_w("WS[%" PRIu32 "]: _onData: %" PRIu32, _clientId, plen);
+      // async_ws_log_w("WS[%" PRIu32 "]: _status = %" PRIu32, _clientId, _status);
+      // async_ws_log_w(
+      //   "WS[%" PRIu32 "]: _pinfo: index: %" PRIu64 ", final: %" PRIu8 ", opcode: %" PRIu8 ", masked: %" PRIu8 ", len: %" PRIu64, _clientId, _pinfo.index,
+      //   _pinfo.final, _pinfo.opcode, _pinfo.masked, _pinfo.len
+      // );
 
       data += 2;
       plen -= 2;
@@ -538,23 +541,47 @@ void AsyncWebSocketClient::_onData(void *pbuf, size_t plen) {
       }
     }
 
-    if (_pinfo.masked > 0 && _pinfo.masked < 5) {
-      // Handle fragmented mask data - Safari may split the 4-byte mask across multiple packets
-      while (_pinfo.masked < 5) {
-        if (plen == 0) {
-          //wait for more data
+    if (_pinfo.masked) {
+      // Read mask bytes (may be fragmented across packets in Safari)
+      size_t mask_offset = 0;
+
+      // If we're resuming from a previous fragmented read, check _pinfo.index
+      if (_pstate == 1 && _pinfo.index < 4) {
+        mask_offset = _pinfo.index;
+      }
+
+      // Read as many mask bytes as available
+      while (mask_offset < 4 && plen > 0) {
+        _pinfo.mask[mask_offset++] = *data++;
+        plen--;
+      }
+
+      // Check if we have all 4 mask bytes
+      if (mask_offset < 4) {
+        // Incomplete mask
+        if (_pinfo.opcode == WS_DISCONNECT && plen == 0) {
+          // Safari close frame edge case: masked bit set but no mask data
+          // async_ws_log_w("WS[%" PRIu32 "]: close frame with incomplete mask, treating as unmasked", _clientId);
+          _pinfo.masked = 0;
+          _pinfo.index = 0;
+        } else {
+          // Wait for more data
+          // async_ws_log_w("WS[%" PRIu32 "]: waiting for more mask data: read=%zu/4", _clientId, mask_offset);
+          _pinfo.index = mask_offset;  // Save progress
           _pstate = 1;
           return;
         }
-        _pinfo.mask[_pinfo.masked - 1] = data[0];
-        data += 1;
-        plen -= 1;
-        _pinfo.masked++;
+      } else {
+        // All mask bytes received
+        // async_ws_log_w("WS[%" PRIu32 "]: mask complete", _clientId);
+        _pinfo.index = 0;  // Reset index for payload processing
       }
     }
 
     const size_t datalen = std::min((size_t)(_pinfo.len - _pinfo.index), plen);
     const auto datalast = data[datalen];
+
+    // async_ws_log_w("WS[%" PRIu32 "]: _processing data: datalen=%" PRIu32 ", plen=%" PRIu32, _clientId, datalen, plen);
 
     if (_pinfo.masked) {
       for (size_t i = 0; i < datalen; i++) {
@@ -614,7 +641,7 @@ void AsyncWebSocketClient::_onData(void *pbuf, size_t plen) {
         }
       }
     } else {
-      // os_printf("frame error: len: %u, index: %llu, total: %llu\n", datalen, _pinfo.index, _pinfo.len);
+      // async_ws_log_w("frame error: len: %u, index: %llu, total: %llu\n", datalen, _pinfo.index, _pinfo.len);
       // what should we do?
       break;
     }


### PR DESCRIPTION
I have a kiosk iPad application that has to use Safari. The iPad app works with this library in 2019, but not with the new iOS and the new library. The fragmented data, especially pong, causes data corruption.

Pong data in Chrome
8A 80 8B 9B 7E 64
Pong data in Safari
8A 80
46 DC 9F 25

This commit addresses the pointer corruption that occurs when Safari sends a Pong. Without this change, the library will use the mask as the beginning of a new data frame and misbehave.

I used _pinfo.masked as a counter to minimize change of the code.