### PR TITLE
Fix #364 Introduce cleanup() function for SSE to be called from loop()

### DIFF
--- a/src/AsyncEventSource.h
+++ b/src/AsyncEventSource.h
@@ -272,6 +272,10 @@ public:
   // close all connected clients
   void close();
 
+  // Cleanup internal resources.
+  // Has to be called periodically in the loop
+  void cleanup();
+
   /**
      * @brief set on-connect callback for the client
      * used to deliver messages to client on first connect


### PR DESCRIPTION
Fix #364 Introduce cleanup() function

This function is similar to `cleanupClients(N)` for WebSocket except that it only cleanups internal resources.

This "book-keeping" function has to be called in the loop().

This is a non-elegant attempt to fix issue #364