### PR TITLE
Fix ESP8266 crash in logging macros due to __FUNCTION__ in flash

### DIFF
--- a/src/AsyncWebServerLogging.h
+++ b/src/AsyncWebServerLogging.h
@@ -81,6 +81,7 @@
 
 /**
  * ESP8266 specific configurations
+ * Note: __FUNCTION__ is stored in flash on ESP8266, so we use FPSTR() to handle it properly
  */
 #elif defined(ESP8266)
 #include <ets_sys.h>
@@ -98,31 +99,31 @@
 #endif
 // error
 #if ASYNCWEBSERVER_LOG_LEVEL >= ASYNC_WS_LOG_ERROR
-#define async_ws_log_e(format, ...) ets_printf(String(F("E async_ws %s() %d: " format)).c_str(), __FUNCTION__, __LINE__, ##__VA_ARGS__);
+#define async_ws_log_e(format, ...) Serial.printf_P(PSTR("E async_ws %d: " format "\n"), __LINE__, ##__VA_ARGS__)
 #else
 #define async_ws_log_e(format, ...)
 #endif
 // warn
 #if ASYNCWEBSERVER_LOG_LEVEL >= ASYNC_WS_LOG_WARN
-#define async_ws_log_w(format, ...) ets_printf(String(F("W async_ws %s() %d: " format)).c_str(), __FUNCTION__, __LINE__, ##__VA_ARGS__);
+#define async_ws_log_w(format, ...) Serial.printf_P(PSTR("W async_ws %d: " format "\n"), __LINE__, ##__VA_ARGS__)
 #else
 #define async_ws_log_w(format, ...)
 #endif
 // info
 #if ASYNCWEBSERVER_LOG_LEVEL >= ASYNC_WS_LOG_INFO
-#define async_ws_log_i(format, ...) ets_printf(String(F("I async_ws %s() %d: " format)).c_str(), __FUNCTION__, __LINE__, ##__VA_ARGS__);
+#define async_ws_log_i(format, ...) Serial.printf_P(PSTR("I async_ws %d: " format "\n"), __LINE__, ##__VA_ARGS__)
 #else
 #define async_ws_log_i(format, ...)
 #endif
 // debug
 #if ASYNCWEBSERVER_LOG_LEVEL >= ASYNC_WS_LOG_DEBUG
-#define async_ws_log_d(format, ...) ets_printf(String(F("D async_ws %s() %d: " format)).c_str(), __FUNCTION__, __LINE__, ##__VA_ARGS__);
+#define async_ws_log_d(format, ...) Serial.printf_P(PSTR("D async_ws %d: " format "\n"), __LINE__, ##__VA_ARGS__)
 #else
 #define async_ws_log_d(format, ...)
 #endif
 // verbose
 #if ASYNCWEBSERVER_LOG_LEVEL >= ASYNC_WS_LOG_VERBOSE
-#define async_ws_log_v(format, ...) ets_printf(String(F("V async_ws %s() %d: " format)).c_str(), __FUNCTION__, __LINE__, ##__VA_ARGS__);
+#define async_ws_log_v(format, ...) Serial.printf_P(PSTR("V async_ws %d: " format "\n"), __LINE__, ##__VA_ARGS__)
 #else
 #define async_ws_log_v(format, ...)
 #endif


### PR DESCRIPTION
On ESP8266, the `__FUNCTION__` macro returns a pointer to flash memory. The logging macros pass this directly to `ets_printf` with `%s`, which expects a RAM pointer. This causes a LoadStoreError (Exception 3) crash whenever any `async_ws_log_*` macro is invoked.

Replace `ets_printf` with `Serial.printf_P` using `PSTR()` for the format string, and remove `__FUNCTION__` since it cannot be safely used with printf on ESP8266.

This bug has existed since the logging refactoring in commit e323ae1 (2025-09-10). Any ESP8266 code path that triggers a log message (e.g., queue overflow, allocation failure) would crash.
