### PR TITLE
Fix: Patch ESP_Async_WebServer const-correctness bug for ESP32

### DIFF
--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -1476,7 +1476,8 @@ public:
     // ESPAsyncTCP and RPAsyncTCP methods are not corrected declared with const for immutable ones.
     return static_cast<tcp_state>(const_cast<AsyncWebServer *>(this)->_server.status());
 #else
-    return static_cast<tcp_state>(_server.status());
+    // ESP32: Same const-correctness workaround needed for AsyncTCP
+    return static_cast<tcp_state>(const_cast<AsyncWebServer *>(this)->_server.status());
 #endif
   }
 


### PR DESCRIPTION
### Root Cause
The ESP_Async_WebServer library has a const-correctness bug in the `AsyncWebServer::state()` method for ESP32. The method is declared as `const` but calls `AsyncServer::status()`, which is not const-qualified.

Interestingly, the ESP8266 branch (line 1477) already has a `const_cast` workaround for this exact issue, but the ESP32 branch (line 1479) was missing it.

### Solution
Applied the same `const_cast` workaround to the ESP32 branch that already exists in the ESP8266 branch.

**File:** `ESP_Async_WebServer/src/ESPAsyncWebServer.h`  
**Line:** 1479

**Before:**
#else
    return static_cast<tcp_state>(_server.status());
#endif
