### PR TITLE
Fix ESP8266 logging to not require global Serial object

### DIFF
--- a/src/AsyncWebServerLogging.h
+++ b/src/AsyncWebServerLogging.h
@@ -104,9 +104,8 @@
 #define _ASYNC_WS_LOG(level, format, ...)                               \
   do {                                                                  \
     static const char __fmt[] PROGMEM = "%c async_ws %d: " format "\n"; \
-    char __buf[64];                                                     \
-    strncpy_P(__buf, __fmt, sizeof(__buf) - 1);                         \
-    __buf[sizeof(__buf) - 1] = '\0';                                    \
+    char __buf[sizeof(__fmt)];                                          \
+    strcpy_P(__buf, __fmt);                                             \
     ets_printf(__buf, level, __LINE__, ##__VA_ARGS__);                  \
   } while (0)
 // error


### PR DESCRIPTION
Fixes #379

PR #371 switched ESP8266 logging from `ets_printf` to `Serial.printf_P`, while nice and convenient for PROGMEM strings on ESP8266, it requires the global `Serial` object. This breaks builds using `NO_GLOBAL_SERIAL` to free up UART0 pins for other purposes.

This change restores using `ets_printf` with PROGMEM format strings and `%c` for the log level (char literals don't consume RAM).

Note: ESPHome may additionally use `ASYNCWEBSERVER_LOG_CUSTOM` to integrate with its own logging system, but that's a separate decision. This PR fixes the regression for all other users.

~~**Untested** - written while traveling and only verified it compiles ok for now. Will test on a real device when I reach a stable work environment.~~

Tested on an esp8266
