### PR TITLE
Fix #384: Remove the buffer overflow intended by design allowing users to add a null terminator after the buffer end

### DIFF
--- a/examples/WebSocket/WebSocket.ino
+++ b/examples/WebSocket/WebSocket.ino
@@ -76,9 +76,11 @@ void setup() {
   // Run in terminal 2: websocat ws://192.168.4.1/ws => should stream data
   // Run in terminal 3: websocat ws://192.168.4.1/ws => should fail:
   //
-  // To send a message to the WebSocket server:
+  // To send a message to the WebSocket server (\n at the end):
+  // > echo "Hello!" | websocat ws://192.168.4.1/ws
   //
-  // echo "Hello!" | websocat ws://192.168.4.1/ws
+  // Generates 2001 characters (\n at the end) to cause a fragmentation (over TCP MSS):
+  // > openssl rand -hex 1000 | websocat ws://192.168.4.1/ws
   //
   ws.onEvent([](AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventType type, void *arg, uint8_t *data, size_t len) {
     (void)len;
@@ -108,7 +110,6 @@ void setup() {
       // complete frame
       if (info->final && info->index == 0 && info->len == len) {
         if (info->opcode == WS_TEXT) {
-          data[len] = 0;
           Serial.printf("ws text: %s\n", (char *)data);
           client->ping();
         }
@@ -130,7 +131,6 @@ void setup() {
         );
 
         if (info->message_opcode == WS_TEXT) {
-          data[len] = 0;
           Serial.printf("%s\n", (char *)data);
         } else {
           for (size_t i = 0; i < len; i++) {

--- a/idf_component_examples/websocket/main/main.cpp
+++ b/idf_component_examples/websocket/main/main.cpp
@@ -55,7 +55,6 @@ void setup() {
       String msg = "";
       if (info->final && info->index == 0 && info->len == len) {
         if (info->opcode == WS_TEXT) {
-          data[len] = 0;
           Serial.printf("ws text: %s\n", (char *)data);
         }
       }

--- a/src/AsyncWebSocket.h
+++ b/src/AsyncWebSocket.h
@@ -554,9 +554,6 @@ private:
       }
     } else if (type == WS_EVT_DATA) {
       AwsFrameInfo *info = (AwsFrameInfo *)arg;
-      if (info->opcode == WS_TEXT) {
-        data[len] = 0;
-      }
       if (info->final && info->index == 0 && info->len == len) {
         if (_onMessage) {
           _onMessage(server, client, data, len);


### PR DESCRIPTION
Fix #384

Initial discussion: https://github.com/ESP32Async/ESPAsyncWebServer/pull/383#discussion_r2760425739

Wifi doc: https://github.com/ESP32Async/ESPAsyncWebServer/wiki#async-websocket-event

Doc requested by design that users add a null terminating char after the buffer ends
