### PR TITLE
Extend Hash.h Crypto library workaround to RP2040/RP2350

### DIFF
--- a/library.json
+++ b/library.json
@@ -39,7 +39,10 @@
     },
     {
       "name": "Hash",
-      "platforms": "espressif8266"
+      "platforms": [
+        "espressif8266",
+        "raspberrypi"
+      ]
     },
     {
       "owner": "ayushsharma82",

--- a/src/AsyncWebSocket.h
+++ b/src/AsyncWebSocket.h
@@ -36,7 +36,7 @@
 #include <list>
 #include <memory>
 
-#ifdef ESP8266
+#if defined(ESP8266) || defined(TARGET_RP2040) || defined(TARGET_RP2350) || defined(PICO_RP2040) || defined(PICO_RP2350)
 #include <Hash.h>
 #ifdef CRYPTO_HASH_h  // include Hash.h from espressif framework if the first include was from the crypto library
 #include <../src/Hash.h>


### PR DESCRIPTION
The ESP8266 codepath in `AsyncWebSocket.h` already has a workaround for when the Crypto library's `Hash.h` gets included instead of the framework's version — it checks for the `CRYPTO_HASH_h` guard and re-includes the correct one via `<../src/Hash.h>`.

RP2040/RP2350 has the same issue since the Arduino-Pico framework also provides a `Hash` library with `sha1()`, but this workaround was never extended when RP2040 support was added.

This showed up in ESPHome CI when `web_server` (ESPAsyncWebServer) and `dsmr` (Crypto-no-arduino) are compiled together on RP2040:

```
AsyncWebSocket.cpp: error: 'sha1' was not declared in this scope
```