### PR TITLE
Review logging across WebSocket implementation

### DIFF
--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -171,8 +171,9 @@ size_t AsyncWebSocketMessage::ack(size_t len, uint32_t time) {
   if (_sent >= _WSbuffer->size() && _acked >= _ack) {
     _status = WS_MSG_SENT;
   }
-  async_ws_log_v("opcode: %" PRIu8 ", acked: %u/%u, left: %u/%u, status: %d", _opcode, _acked, _ack, len - pending, len, static_cast<int>(_status));
-  return len - pending;
+  const size_t remaining = len - pending;
+  async_ws_log_v("ACK[%" PRIu8 "] %u/%u (acked: %u/%u) => %" PRIu8, _opcode, _sent, _WSbuffer->size(), _acked, _ack, static_cast<uint8_t>(_status));
+  return remaining;
 }
 
 size_t AsyncWebSocketMessage::send(AsyncClient *client) {
@@ -182,7 +183,7 @@ size_t AsyncWebSocketMessage::send(AsyncClient *client) {
   }
 
   if (_status != WS_MSG_SENDING) {
-    async_ws_log_v("C[%" PRIu16 "] Wrong status: got: %d, expected: %d", client->remotePort(), static_cast<int>(_status), static_cast<int>(WS_MSG_SENDING));
+    async_ws_log_v("SEND[%" PRIu8 "] => [%" PRIu16 "] WS_MSG_SENDING != %" PRIu8, _opcode, client->remotePort(), static_cast<uint8_t>(_status));
     return 0;
   }
 
@@ -190,12 +191,14 @@ size_t AsyncWebSocketMessage::send(AsyncClient *client) {
     if (_acked == _ack) {
       _status = WS_MSG_SENT;
     }
-    async_ws_log_v("C[%" PRIu16 "] Already sent: %u/%u", client->remotePort(), _sent, _WSbuffer->size());
+    async_ws_log_v("SEND[%" PRIu8 "] => [%" PRIu16 "] WS_MSG_SENT %u/%u (acked: %u/%u)", _opcode, client->remotePort(), _sent, _WSbuffer->size(), _acked, _ack);
     return 0;
   }
   if (_sent > _WSbuffer->size()) {
     _status = WS_MSG_ERROR;
-    async_ws_log_v("C[%" PRIu16 "] Error, sent more: %u/%u", client->remotePort(), _sent, _WSbuffer->size());
+    async_ws_log_v(
+      "SEND[%" PRIu8 "] => [%" PRIu16 "] WS_MSG_ERROR %u/%u (acked: %u/%u)", _opcode, client->remotePort(), _sent, _WSbuffer->size(), _acked, _ack
+    );
     return 0;
   }
 
@@ -204,7 +207,7 @@ size_t AsyncWebSocketMessage::send(AsyncClient *client) {
 
   // not enough space in lwip buffer ?
   if (!window) {
-    async_ws_log_v("C[%" PRIu16 "] No space left to send more data: acked: %u, sent: %u, remaining: %u", client->remotePort(), _acked, _sent, toSend);
+    async_ws_log_v("SEND[%" PRIu8 "] => [%" PRIu16 "] NO_SPACE %u", _opcode, client->remotePort(), toSend);
     return 0;
   }
 
@@ -224,7 +227,9 @@ size_t AsyncWebSocketMessage::send(AsyncClient *client) {
     _ack -= (toSend - sent);
   }
 
-  async_ws_log_v("C[%" PRIu16 "] sent: %u/%u, final: %d, acked: %u/%u", client->remotePort(), _sent, _WSbuffer->size(), final, _acked, _ack);
+  async_ws_log_v(
+    "SEND[%" PRIu8 "] => [%" PRIu16 "] WS_MSG_SENDING %u/%u (acked: %u/%u)", _opcode, client->remotePort(), _sent, _WSbuffer->size(), _acked, _ack
+  );
   return sent;
 }
 
@@ -304,6 +309,8 @@ void AsyncWebSocketClient::_clearQueue() {
 void AsyncWebSocketClient::_onAck(size_t len, uint32_t time) {
   _lastMessageTime = millis();
 
+  async_ws_log_v("[%s][%" PRIu32 "] START ACK(%u, %" PRIu32 ") Q:%u", _server->url(), _clientId, len, time, _messageQueue.size());
+
 #ifdef ESP32
   std::unique_lock<std::recursive_mutex> lock(_lock);
 #endif
@@ -315,6 +322,7 @@ void AsyncWebSocketClient::_onAck(size_t len, uint32_t time) {
       if (_status == WS_DISCONNECTING && head.opcode() == WS_DISCONNECT) {
         _controlQueue.pop_front();
         _status = WS_DISCONNECTED;
+        async_ws_log_v("[%s][%" PRIu32 "] ACK WS_DISCONNECTED", _server->url(), _clientId);
         if (_client) {
 #ifdef ESP32
           /*
@@ -342,6 +350,8 @@ void AsyncWebSocketClient::_onAck(size_t len, uint32_t time) {
   }
 
   _clearQueue();
+
+  async_ws_log_v("[%s][%" PRIu32 "] END ACK(%u, %" PRIu32 ") Q:%u", _server->url(), _clientId, len, time, _messageQueue.size());
 
   _runQueue();
 }
@@ -386,7 +396,7 @@ void AsyncWebSocketClient::_runQueue() {
           continue;
         }
         if (space > (size_t)(ctrl.len() - 1)) {
-          async_ws_log_v("WS[%" PRIu32 "] Sending control frame: %" PRIu8 ", len: %" PRIu8, _clientId, ctrl.opcode(), ctrl.len());
+          async_ws_log_v("[%s][%" PRIu32 "] SEND CTRL %" PRIu8, _server->url(), _clientId, ctrl.opcode());
           ctrl.send(_client);
           space = webSocketSendFrameWindow(_client);
         }
@@ -398,9 +408,10 @@ void AsyncWebSocketClient::_runQueue() {
       for (auto &msg : _messageQueue) {
         if (msg._remainingBytesToSend()) {
           async_ws_log_v(
-            "WS[%" PRIu32 "] Send message fragment: %u/%u, acked: %u/%u", _clientId, msg._remainingBytesToSend(), msg._sent + msg._remainingBytesToSend(),
-            msg._acked, msg._ack
+            "[%s][%" PRIu32 "][%" PRIu8 "] SEND %u/%u (acked: %u/%u)", _server->url(), _clientId, msg._opcode, msg._sent, msg._WSbuffer->size(), msg._acked,
+            msg._ack
           );
+
           // will use all the remaining space, or all the remaining bytes to send, whichever is smaller
           msg.send(_client);
           space = webSocketSendFrameWindow(_client);
@@ -408,12 +419,12 @@ void AsyncWebSocketClient::_runQueue() {
           // If we haven't finished sending this message, we must stop here to preserve WebSocket ordering.
           // We can only pipeline subsequent messages if the current one is fully passed to TCP buffer.
           if (msg._remainingBytesToSend()) {
+            async_ws_log_v("[%s][%" PRIu32 "][%" PRIu8 "] NO_SPACE", _server->url(), _clientId, msg._opcode);
             break;
           }
-        }
-
-        // not enough space for another message
-        if (!space) {
+        } else if (!space) {
+          // not enough space for another message
+          async_ws_log_v("[%s][%" PRIu32 "] NO_SPACE", _server->url(), _clientId);
           break;
         }
       }
@@ -452,6 +463,7 @@ bool AsyncWebSocketClient::_queueControl(uint8_t opcode, const uint8_t *data, si
 #endif
 
   _controlQueue.emplace_back(opcode, data, len, mask);
+  async_ws_log_v("[%s][%" PRIu32 "] QUEUE CTRL (%u) << %" PRIu8, _server->url(), _clientId, _controlQueue.size(), opcode);
 
   if (_client && _client->canSend()) {
     _runQueue();
@@ -485,16 +497,17 @@ bool AsyncWebSocketClient::_queueMessage(AsyncWebSocketSharedBuffer buffer, uint
         _client->close();
       }
 
-      async_ws_log_w("Too many messages queued: closing connection");
+      async_ws_log_w("[%s][%" PRIu32 "] Too many messages queued: closing connection", _server->url(), _clientId);
 
     } else {
-      async_ws_log_w("Too many messages queued: discarding new message");
+      async_ws_log_w("[%s][%" PRIu32 "] Too many messages queued: discarding new message", _server->url(), _clientId);
     }
 
     return false;
   }
 
   _messageQueue.emplace_back(buffer, opcode, mask);
+  async_ws_log_v("[%s][%" PRIu32 "] QUEUE MSG (%u/%u) << %" PRIu8, _server->url(), _clientId, _messageQueue.size(), WS_MAX_QUEUED_MESSAGES, opcode);
 
   if (_client && _client->canSend()) {
     _runQueue();
@@ -507,6 +520,8 @@ void AsyncWebSocketClient::close(uint16_t code, const char *message) {
   if (_status != WS_CONNECTED) {
     return;
   }
+
+  async_ws_log_w("[%s][%" PRIu32 "] CLOSE", _server->url(), _clientId);
 
   _status = WS_DISCONNECTING;
 
@@ -541,21 +556,20 @@ bool AsyncWebSocketClient::ping(const uint8_t *data, size_t len) {
   return _status == WS_CONNECTED && _queueControl(WS_PING, data, len);
 }
 
-void AsyncWebSocketClient::_onError(int8_t) {
-  // Serial.println("onErr");
+void AsyncWebSocketClient::_onError(int8_t err) {
+  async_ws_log_v("[%s][%" PRIu32 "] ERROR %" PRIi8, _server->url(), _clientId, static_cast<int8_t>(err));
 }
 
 void AsyncWebSocketClient::_onTimeout(uint32_t time) {
   if (!_client) {
     return;
   }
-  // Serial.println("onTime");
-  (void)time;
+  async_ws_log_v("[%s][%" PRIu32 "] TIMEOUT %" PRIu32, _server->url(), _clientId, time);
   _client->close();
 }
 
 void AsyncWebSocketClient::_onDisconnect() {
-  // Serial.println("onDis");
+  async_ws_log_v("[%s][%" PRIu32 "] DISCONNECT", _server->url(), _clientId);
   _client = nullptr;
   _server->_handleDisconnect(this);
 }
@@ -566,7 +580,7 @@ void AsyncWebSocketClient::_onData(void *pbuf, size_t plen) {
 
   while (plen > 0) {
     async_ws_log_v(
-      "WS[%" PRIu32 "] _onData: plen: %" PRIu32 ", _pstate: %" PRIu8 ", _status: %" PRIu8, _clientId, plen, _pstate, static_cast<uint8_t>(_status)
+      "[%s][%" PRIu32 "] DATA plen: %" PRIu32 ", _pstate: %" PRIu8 ", _status: %" PRIu8, _server->url(), _clientId, plen, _pstate, static_cast<uint8_t>(_status)
     );
 
     if (_pstate == STATE_FRAME_START) {
@@ -595,8 +609,8 @@ void AsyncWebSocketClient::_onData(void *pbuf, size_t plen) {
     }
 
     async_ws_log_v(
-      "WS[%" PRIu32 "] _pinfo: index: %" PRIu64 ", final: %" PRIu8 ", opcode: %" PRIu8 ", masked: %" PRIu8 ", len: %" PRIu64, _clientId, _pinfo.index,
-      _pinfo.final, _pinfo.opcode, _pinfo.masked, _pinfo.len
+      "[%s][%" PRIu32 "] DATA _pinfo: index: %" PRIu64 ", final: %" PRIu8 ", opcode: %" PRIu8 ", masked: %" PRIu8 ", len: %" PRIu64, _server->url(), _clientId,
+      _pinfo.index, _pinfo.final, _pinfo.opcode, _pinfo.masked, _pinfo.len
     );
 
     // Handle fragmented mask data - Safari may split the 4-byte mask across multiple packets
@@ -608,7 +622,7 @@ void AsyncWebSocketClient::_onData(void *pbuf, size_t plen) {
       if (plen == 0) {
         // Safari close frame edge case: masked bit set but no mask data
         if (_pinfo.opcode == WS_DISCONNECT) {
-          async_ws_log_v("WS[%" PRIu32 "] close frame with incomplete mask, treating as unmasked", _clientId);
+          async_ws_log_v("[%s][%" PRIu32 "] DATA close frame with incomplete mask, treating as unmasked", _server->url(), _clientId);
           _pinfo.masked = 0;
           _pinfo.index = 0;
           _pinfo.len = 0;
@@ -616,9 +630,9 @@ void AsyncWebSocketClient::_onData(void *pbuf, size_t plen) {
           break;
         }
 
-        //wait for more data
+        // wait for more data
         _pstate = STATE_FRAME_MASK;
-        async_ws_log_v("WS[%" PRIu32 "] waiting for more mask data: read: %" PRIu8 "/4", _clientId, _pinfo.masked - 1);
+        async_ws_log_v("[%s][%" PRIu32 "] DATA waiting for more mask data: read: %" PRIu8 "/4", _server->url(), _clientId, _pinfo.masked - 1);
         return;
       }
 
@@ -634,7 +648,7 @@ void AsyncWebSocketClient::_onData(void *pbuf, size_t plen) {
 
     // restore masked to 1 for backward compatibility
     if (_pinfo.masked >= 5) {
-      async_ws_log_v("WS[%" PRIu32 "] mask read complete", _clientId);
+      async_ws_log_v("[%s][%" PRIu32 "] DATA mask read complete", _server->url(), _clientId);
       _pinfo.masked = 1;
     }
 
@@ -663,7 +677,7 @@ void AsyncWebSocketClient::_onData(void *pbuf, size_t plen) {
 
       if (datalen > 0) {
         async_ws_log_v(
-          "WS[%" PRIu32 "] processing next fragment of %s frame %" PRIu32 ", index: %" PRIu64 ", len: %" PRIu32 "", _clientId,
+          "[%s][%" PRIu32 "] DATA processing next fragment of %s frame %" PRIu32 ", index: %" PRIu64 ", len: %" PRIu32 "", _server->url(), _clientId,
           (_pinfo.message_opcode == WS_TEXT) ? "text" : "binary", _pinfo.num, _pinfo.index, (uint32_t)datalen
         );
         _handleDataEvent(data, datalen, datalen == plen);  // datalen == plen means that we are processing the last part of the current TCP packet
@@ -676,7 +690,7 @@ void AsyncWebSocketClient::_onData(void *pbuf, size_t plen) {
       _pstate = STATE_FRAME_START;
 
       if (_pinfo.opcode == WS_DISCONNECT) {
-        async_ws_log_v("WS[%" PRIu32 "] processing disconnect", _clientId);
+        async_ws_log_v("[%s][%" PRIu32 "] DATA WS_DISCONNECT", _server->url(), _clientId);
 
         if (datalen) {
           uint16_t reasonCode = (uint16_t)(data[0] << 8) + data[1];
@@ -699,19 +713,19 @@ void AsyncWebSocketClient::_onData(void *pbuf, size_t plen) {
         }
 
       } else if (_pinfo.opcode == WS_PING) {
-        async_ws_log_v("WS[%" PRIu32 "] processing ping", _clientId);
+        async_ws_log_v("[%s][%" PRIu32 "] DATA PING", _server->url(), _clientId);
         _server->_handleEvent(this, WS_EVT_PING, NULL, NULL, 0);
         _queueControl(WS_PONG, data, datalen);
 
       } else if (_pinfo.opcode == WS_PONG) {
-        async_ws_log_v("WS[%" PRIu32 "] processing pong", _clientId);
+        async_ws_log_v("[%s][%" PRIu32 "] DATA PONG", _server->url(), _clientId);
         if (datalen != AWSC_PING_PAYLOAD_LEN || memcmp(AWSC_PING_PAYLOAD, data, AWSC_PING_PAYLOAD_LEN) != 0) {
           _server->_handleEvent(this, WS_EVT_PONG, NULL, NULL, 0);
         }
 
       } else if (_pinfo.opcode < WS_DISCONNECT) {  // continuation or text/binary frame
         async_ws_log_v(
-          "WS[%" PRIu32 "] processing final fragment of %s frame %" PRIu32 ", index: %" PRIu64 ", len: %" PRIu32 "", _clientId,
+          "[%s][%" PRIu32 "] DATA processing final fragment of %s frame %" PRIu32 ", index: %" PRIu64 ", len: %" PRIu32 "", _server->url(), _clientId,
           (_pinfo.message_opcode == WS_TEXT) ? "text" : "binary", _pinfo.num, _pinfo.index, (uint32_t)datalen
         );
 
@@ -728,7 +742,9 @@ void AsyncWebSocketClient::_onData(void *pbuf, size_t plen) {
       // unexpected frame error, close connection
       _pstate = STATE_FRAME_START;
 
-      async_ws_log_v("frame error: len: %u, index: %llu, total: %llu\n", datalen, _pinfo.index, _pinfo.len);
+      async_ws_log_v(
+        "[%s][%" PRIu32 "] DATA frame error: len: %u, index: %" PRIu64 ", total: %" PRIu64 "\n", _server->url(), _clientId, datalen, _pinfo.index, _pinfo.len
+      );
 
       _status = WS_DISCONNECTING;
       if (_client) {
@@ -1038,7 +1054,9 @@ void AsyncWebSocket::closeAll(uint16_t code, const char *message) {
 }
 
 void AsyncWebSocket::cleanupClients(uint16_t maxClients) {
-  if (count() > maxClients) {
+  const size_t c = count();
+  if (c > maxClients) {
+    async_ws_log_v("[%s] CLEANUP %" PRIu32 " (%u/%" PRIu16 ")", _url.c_str(), _clients.front().id(), c, maxClients);
     _clients.front().close();
   }
 


### PR DESCRIPTION
This PR adds some verbose logging to the WebSocket implementation on top of the existing one (which as been reviewed) in order to help users debug.

Example when using `USE_ESP_IDF_LOG`:

```
  -D USE_ESP_IDF_LOG
  -D LOG_LOCAL_LEVEL=ESP_LOG_VERBOSE
  -D CORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_VERBOSE
```

```c++
  esp_log_level_set("*", ESP_LOG_DEBUG);
  esp_log_level_set("esp_core_dump_elf", ESP_LOG_INFO);
  esp_log_level_set("esp_core_dump_port", ESP_LOG_INFO);
  esp_log_level_set("esp_netif_lwip", ESP_LOG_INFO);
  esp_log_level_set("nvs", ESP_LOG_INFO);
  esp_log_level_set("ARDUINO", ESP_LOG_DEBUG);

  // to debug async_tcp + async_ws
  esp_log_level_set("async_tcp", ESP_LOG_VERBOSE);
  esp_log_level_set("async_ws", ESP_LOG_VERBOSE);
```

Output example

```
V (25869) async_ws: _queueMessage() 510: [/dashws][1] QUEUE MSG (1/16) << 2
V (25870) async_ws: _runQueue() 410: [/dashws][1][2] SEND 0/313 (acked: 0/0)
V (25882) async_ws: send() 230: SEND[2] => [63930] WS_MSG_SENDING 313/313 (acked: 0/317)
V (25887) async_ws: _onAck() 312: [/dashws][1] START ACK(317, 6) Q:1
V (25887) async_ws: ack() 175: ACK[2] 313/313 (acked: 317/317) => 1
V (25898) async_ws: _onAck() 354: [/dashws][1] END ACK(0, 6) Q:0
V (26157) async_ws: _onData() 582: [/dashws][1] DATA plen: 8, _pstate: 0, _status: 1
V (26159) async_ws: _onData() 611: [/dashws][1] DATA _pinfo: index: 0, final: 1, opcode: 8, masked: 1, len: 2
V (26169) async_ws: _onData() 651: [/dashws][1] DATA mask read complete
V (26179) async_ws: _onData() 693: [/dashws][1] DATA WS_DISCONNECT
V (26180) async_ws: _queueControl() 466: [/dashws][1] QUEUE CTRL (1) << 8
V (26192) async_ws: _onDisconnect() 572: [/dashws][1] DISCONNECT
V (26518) async_ws: _onData() 582: [/dashws][2] DATA plen: 26, _pstate: 0, _status: 1
V (26520) async_ws: _onData() 611: [/dashws][2] DATA _pinfo: index: 0, final: 1, opcode: 2, masked: 1, len: 20
V (26530) async_ws: _onData() 651: [/dashws][2] DATA mask read complete
V (26541) async_ws: _onData() 727: [/dashws][2] DATA processing final fragment of binary frame 0, index: 0, len: 20
I (26552) YASOLR: Dashboard refresh requested!
V (26569) async_ws: _queueMessage() 510: [/dashws][2] QUEUE MSG (1/16) << 2
V (26570) async_ws: _runQueue() 410: [/dashws][2][2] SEND 0/509 (acked: 0/0)
V (26582) async_ws: send() 230: SEND[2] => [64045] WS_MSG_SENDING 509/509 (acked: 0/513)
V (26590) async_ws: _queueMessage() 510: [/dashws][2] QUEUE MSG (2/16) << 2
V (26591) async_ws: _runQueue() 410: [/dashws][2][2] SEND 0/1757 (acked: 0/0)
V (26603) async_ws: send() 230: SEND[2] => [64045] WS_MSG_SENDING 1757/1757 (acked: 0/1761)
V (26616) async_ws: _queueMessage() 510: [/dashws][2] QUEUE MSG (3/16) << 2
V (26616) async_ws: _runQueue() 410: [/dashws][2][2] SEND 0/2107 (acked: 0/0)
V (26628) async_ws: send() 230: SEND[2] => [64045] WS_MSG_SENDING 2107/2107 (acked: 0/2111)
V (26641) async_ws: _queueMessage() 510: [/dashws][2] QUEUE MSG (4/16) << 2
V (26641) async_ws: _runQueue() 410: [/dashws][2][2] SEND 0/2099 (acked: 0/0)
V (26653) async_ws: send() 230: SEND[2] => [64045] WS_MSG_SENDING 2099/2099 (acked: 0/2103)
V (26664) async_ws: _queueMessage() 510: [/dashws][2] QUEUE MSG (5/16) << 2
V (26665) async_ws: _runQueue() 410: [/dashws][2][2] SEND 0/2094 (acked: 0/0)
V (26676) async_ws: send() 230: SEND[2] => [64045] WS_MSG_SENDING 2094/2094 (acked: 0/2098)
V (26687) async_ws: _queueMessage() 510: [/dashws][2] QUEUE MSG (6/16) << 2
V (26688) async_ws: _runQueue() 410: [/dashws][2][2] SEND 0/2102 (acked: 0/0)
V (26699) async_ws: send() 230: SEND[2] => [64045] WS_MSG_SENDING 2102/2102 (acked: 0/2106)
V (26708) async_ws: _queueMessage() 510: [/dashws][2] QUEUE MSG (7/16) << 2
V (26708) async_ws: _runQueue() 410: [/dashws][2][2] SEND 0/2114 (acked: 0/0)
V (26720) async_ws: send() 230: SEND[2] => [64045] WS_MSG_SENDING 2114/2114 (acked: 0/2118)
V (26727) async_ws: _queueMessage() 510: [/dashws][2] QUEUE MSG (8/16) << 2
V (26727) async_ws: _runQueue() 410: [/dashws][2][2] SEND 0/2626 (acked: 0/0)
V (26739) async_ws: send() 230: SEND[2] => [64045] WS_MSG_SENDING 2626/2626 (acked: 0/2630)
V (26751) async_ws: _queueMessage() 510: [/dashws][2] QUEUE MSG (9/16) << 2
V (26751) async_ws: _runQueue() 410: [/dashws][2][2] SEND 0/2133 (acked: 0/0)
V (26764) async_ws: send() 230: SEND[2] => [64045] WS_MSG_SENDING 2133/2133 (acked: 0/2137)
V (26775) async_ws: _queueMessage() 510: [/dashws][2] QUEUE MSG (10/16) << 2
V (26775) async_ws: _runQueue() 410: [/dashws][2][2] SEND 0/2105 (acked: 0/0)
V (26787) async_ws: send() 230: SEND[2] => [64045] WS_MSG_SENDING 2105/2105 (acked: 0/2109)
V (26791) async_ws: _queueMessage() 510: [/dashws][2] QUEUE MSG (11/16) << 2
V (26802) async_ws: _runQueue() 410: [/dashws][2][2] SEND 0/398 (acked: 0/0)
V (26803) async_ws: send() 230: SEND[2] => [64045] WS_MSG_SENDING 398/398 (acked: 0/402)
V (26818) async_ws: _onAck() 312: [/dashws][2] START ACK(513, 16) Q:11
V (26819) async_ws: ack() 175: ACK[2] 509/509 (acked: 513/513) => 1
V (26830) async_ws: _onAck() 354: [/dashws][2] END ACK(0, 16) Q:10
V (26830) async_ws: _onAck() 312: [/dashws][2] START ACK(1761, 27) Q:10
V (26840) async_ws: ack() 175: ACK[2] 1757/1757 (acked: 1761/1761) => 1
V (26841) async_ws: _onAck() 354: [/dashws][2] END ACK(0, 27) Q:9
V (26851) async_ws: _onAck() 312: [/dashws][2] START ACK(1436, 49) Q:9
V (26851) async_ws: ack() 175: ACK[2] 2107/2107 (acked: 1436/2111) => 0
V (26862) async_ws: _onAck() 354: [/dashws][2] END ACK(0, 49) Q:9
V (26862) async_ws: _onAck() 312: [/dashws][2] START ACK(675, 60) Q:9
V (26872) async_ws: ack() 175: ACK[2] 2107/2107 (acked: 2111/2111) => 1
V (26883) async_ws: _onAck() 354: [/dashws][2] END ACK(0, 60) Q:8
V (26883) async_ws: _onAck() 312: [/dashws][2] START ACK(1436, 81) Q:8
V (26891) async_ws: _queueMessage() 510: [/dashws][2] QUEUE MSG (9/16) << 2
V (26894) async_ws: _runQueue() 410: [/dashws][2][2] SEND 0/394 (acked: 0/0)
V (26906) async_ws: send() 230: SEND[2] => [64045] WS_MSG_SENDING 394/394 (acked: 0/398)
V (26917) async_ws: ack() 175: ACK[2] 2099/2099 (acked: 1436/2103) => 0
V (26917) async_ws: _onAck() 354: [/dashws][2] END ACK(0, 81) Q:9
V (26927) async_ws: _onAck() 312: [/dashws][2] START ACK(667, 22) Q:9
V (26928) async_ws: ack() 175: ACK[2] 2099/2099 (acked: 2103/2103) => 1
V (26938) async_ws: _onAck() 354: [/dashws][2] END ACK(0, 22) Q:8
V (26938) async_ws: _onAck() 312: [/dashws][2] START ACK(1436, 33) Q:8
V (26949) async_ws: ack() 175: ACK[2] 2094/2094 (acked: 1436/2098) => 0
V (26949) async_ws: _onAck() 354: [/dashws][2] END ACK(0, 33) Q:8
V (26959) async_ws: _onAck() 312: [/dashws][2] START ACK(662, 54) Q:8
V (26970) async_ws: ack() 175: ACK[2] 2094/2094 (acked: 2098/2098) => 1
V (26970) async_ws: _onAck() 354: [/dashws][2] END ACK(0, 54) Q:7
V (26981) async_ws: _onAck() 312: [/dashws][2] START ACK(2106, 75) Q:7
V (26981) async_ws: ack() 175: ACK[2] 2102/2102 (acked: 2106/2106) => 1
V (26991) async_ws: _onAck() 354: [/dashws][2] END ACK(0, 75) Q:6
V (26991) async_ws: _onAck() 312: [/dashws][2] START ACK(1436, 86) Q:6
V (27002) async_ws: ack() 175: ACK[2] 2114/2114 (acked: 1436/2118) => 0
V (27012) async_ws: _onAck() 354: [/dashws][2] END ACK(0, 86) Q:6
V (27013) async_ws: _onAck() 312: [/dashws][2] START ACK(682, 107) Q:6
V (27023) async_ws: ack() 175: ACK[2] 2114/2114 (acked: 2118/2118) => 1
V (27023) async_ws: _onAck() 354: [/dashws][2] END ACK(0, 107) Q:5
V (27034) async_ws: _onAck() 312: [/dashws][2] START ACK(1436, 128) Q:5
V (27034) async_ws: ack() 175: ACK[2] 2626/2626 (acked: 1436/2630) => 0
V (27044) async_ws: _onAck() 354: [/dashws][2] END ACK(0, 128) Q:5
V (27055) async_ws: _onAck() 312: [/dashws][2] START ACK(1194, 149) Q:5
V (27055) async_ws: ack() 175: ACK[2] 2626/2626 (acked: 2630/2630) => 1
V (27065) async_ws: _onAck() 354: [/dashws][2] END ACK(0, 149) Q:4
V (27066) async_ws: _onAck() 312: [/dashws][2] START ACK(2137, 160) Q:4
V (27076) async_ws: ack() 175: ACK[2] 2133/2133 (acked: 2137/2137) => 1
V (27077) async_ws: _onAck() 354: [/dashws][2] END ACK(0, 160) Q:3
V (27087) async_ws: _onAck() 312: [/dashws][2] START ACK(2109, 182) Q:3
V (27098) async_ws: ack() 175: ACK[2] 2105/2105 (acked: 2109/2109) => 1
V (27098) async_ws: _onAck() 354: [/dashws][2] END ACK(0, 182) Q:2
V (27108) async_ws: _onAck() 312: [/dashws][2] START ACK(402, 203) Q:2
V (27109) async_ws: ack() 175: ACK[2] 398/398 (acked: 402/402) => 1
V (27119) async_ws: _onAck() 354: [/dashws][2] END ACK(0, 203) Q:1
V (27123) async_ws: _onAck() 312: [/dashws][2] START ACK(398, 217) Q:1
V (27133) async_ws: ack() 175: ACK[2] 394/394 (acked: 398/398) => 1
V (27134) async_ws: _onAck() 354: [/dashws][2] END ACK(0, 217) Q:0
```