### PR TITLE
 Introduce request#isMethod(...) to check the http method of the request (fixes #398)

### DIFF
--- a/src/AsyncJson.cpp
+++ b/src/AsyncJson.cpp
@@ -115,15 +115,14 @@ size_t AsyncMessagePackResponse::_fillBuffer(uint8_t *data, size_t len) {
 
 #if ARDUINOJSON_VERSION_MAJOR == 6
 AsyncCallbackJsonWebHandler::AsyncCallbackJsonWebHandler(AsyncURIMatcher uri, ArJsonRequestHandlerFunction onRequest, size_t maxJsonBufferSize)
-  : _uri(std::move(uri)), _method(HTTP_GET | HTTP_POST | HTTP_PUT | HTTP_PATCH), _onRequest(onRequest), maxJsonBufferSize(maxJsonBufferSize),
-    _maxContentLength(16384) {}
+  : _uri(std::move(uri)), _method(HTTP_ANY), _onRequest(onRequest), maxJsonBufferSize(maxJsonBufferSize), _maxContentLength(16384) {}
 #else
 AsyncCallbackJsonWebHandler::AsyncCallbackJsonWebHandler(AsyncURIMatcher uri, ArJsonRequestHandlerFunction onRequest)
-  : _uri(std::move(uri)), _method(HTTP_GET | HTTP_POST | HTTP_PUT | HTTP_PATCH), _onRequest(onRequest), _maxContentLength(16384) {}
+  : _uri(std::move(uri)), _method(HTTP_ANY), _onRequest(onRequest), _maxContentLength(16384) {}
 #endif
 
 bool AsyncCallbackJsonWebHandler::canHandle(AsyncWebServerRequest *request) const {
-  if (!_onRequest || !request->isHTTP() || !(_method & request->method())) {
+  if (!_onRequest || !request->isHTTP() || !request->isMethod(_method)) {
     return false;
   }
 

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -41,8 +41,6 @@
 #include <ESPAsyncTCP.h>
 #elif defined(TARGET_RP2040) || defined(TARGET_RP2350) || defined(PICO_RP2040) || defined(PICO_RP2350)
 #include <RPAsyncTCP.h>
-#include <HTTP_Method.h>
-#include <http_parser.h>
 #else
 #error Platform not supported
 #endif
@@ -80,10 +78,6 @@ class AsyncCallbackWebHandler;
 class AsyncResponseStream;
 class AsyncMiddlewareChain;
 
-#if defined(TARGET_RP2040) || defined(TARGET_RP2350) || defined(PICO_RP2040) || defined(PICO_RP2350)
-typedef enum http_method WebRequestMethod;
-#else
-#ifndef WEBSERVER_H
 typedef enum {
   HTTP_GET = 0b0000000000000001,
   HTTP_POST = 0b0000000000000010,
@@ -102,8 +96,6 @@ typedef enum {
   HTTP_RESERVED = 0b0100000000000000,
   HTTP_ANY = 0b0111111111111111,
 } WebRequestMethod;
-#endif
-#endif
 
 #ifndef HAVE_FS_FILE_OPEN_MODE
 namespace fs {
@@ -346,6 +338,9 @@ public:
   }
   WebRequestMethodComposite method() const {
     return _method;
+  }
+  bool isMethod(WebRequestMethodComposite method) const {
+    return (_method & method) != 0;
   }
   const String &url() const {
     return _url;

--- a/src/WebHandlers.cpp
+++ b/src/WebHandlers.cpp
@@ -300,7 +300,7 @@ void AsyncCallbackWebHandler::setUri(AsyncURIMatcher uri) {
 }
 
 bool AsyncCallbackWebHandler::canHandle(AsyncWebServerRequest *request) const {
-  if (!_onRequest || !request->isHTTP() || !(_method & request->method())) {
+  if (!_onRequest || !request->isHTTP() || !request->isMethod(_method)) {
     return false;
   }
   return _uri.matches(request);

--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -1314,46 +1314,46 @@ const char *AsyncWebServerRequest::methodToString() const {
   if (_method == HTTP_ANY) {
     return T_ANY;
   }
-  if (_method & HTTP_GET) {
+  if (isMethod(HTTP_GET)) {
     return T_GET;
   }
-  if (_method & HTTP_POST) {
+  if (isMethod(HTTP_POST)) {
     return T_POST;
   }
-  if (_method & HTTP_DELETE) {
+  if (isMethod(HTTP_DELETE)) {
     return T_DELETE;
   }
-  if (_method & HTTP_PUT) {
+  if (isMethod(HTTP_PUT)) {
     return T_PUT;
   }
-  if (_method & HTTP_PATCH) {
+  if (isMethod(HTTP_PATCH)) {
     return T_PATCH;
   }
-  if (_method & HTTP_HEAD) {
+  if (isMethod(HTTP_HEAD)) {
     return T_HEAD;
   }
-  if (_method & HTTP_OPTIONS) {
+  if (isMethod(HTTP_OPTIONS)) {
     return T_OPTIONS;
   }
-  if (_method & HTTP_PROPFIND) {
+  if (isMethod(HTTP_PROPFIND)) {
     return T_PROPFIND;
   }
-  if (_method & HTTP_LOCK) {
+  if (isMethod(HTTP_LOCK)) {
     return T_LOCK;
   }
-  if (_method & HTTP_UNLOCK) {
+  if (isMethod(HTTP_UNLOCK)) {
     return T_UNLOCK;
   }
-  if (_method & HTTP_PROPPATCH) {
+  if (isMethod(HTTP_PROPPATCH)) {
     return T_PROPPATCH;
   }
-  if (_method & HTTP_MKCOL) {
+  if (isMethod(HTTP_MKCOL)) {
     return T_MKCOL;
   }
-  if (_method & HTTP_MOVE) {
+  if (isMethod(HTTP_MOVE)) {
     return T_MOVE;
   }
-  if (_method & HTTP_COPY) {
+  if (isMethod(HTTP_COPY)) {
     return T_COPY;
   }
   return T_UNKNOWN;


### PR DESCRIPTION
Fixes #398

Note: this PR does not fix the definition in arduino-pico.

Instead, it provides a new way to check for a request method, and this way is implemented differently in PICO.

If users are still reegistering their handler in PICO with `|` like that

```c++
webServer.on("/ping", HTTP_GET | HTTP_POST, [](AsyncWebServerRequest* request) {
  request->send(200, "text/plain", "pong");
});
```

then of course it won't solve anything.
