### PR TITLE
Added HTTPMethods example

### DIFF
--- a/examples/HTTPMethods/HTTPMethods.ino
+++ b/examples/HTTPMethods/HTTPMethods.ino
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright 2016-2026 Hristo Gochkov, Mathieu Carbou, Emil Muratov, Will Miles
+
+//
+// HTTP Method usage example and check compatibility with Arduino HTTP Methods
+//
+
+#include <Arduino.h>
+
+#if !defined(ESP8266)
+// simulate asyncws project being used with another library using Arduino HTTP Methods
+#include <HTTP_Method.h>
+#endif
+
+#if defined(ESP32) || defined(LIBRETINY)
+#include <AsyncTCP.h>
+#include <WiFi.h>
+#elif defined(ESP8266)
+#include <ESP8266WiFi.h>
+#include <ESPAsyncTCP.h>
+#elif defined(TARGET_RP2040) || defined(TARGET_RP2350) || defined(PICO_RP2040) || defined(PICO_RP2350)
+#include <RPAsyncTCP.h>
+#include <WiFi.h>
+#endif
+
+#define ASYNCWEBSERVER_NO_GLOBAL_HTTP_METHODS 1
+#undef HTTP_ANY
+#include <ESPAsyncWebServer.h>
+
+static AsyncWebServer server(80);
+
+void setup() {
+  Serial.begin(115200);
+
+#if ASYNCWEBSERVER_WIFI_SUPPORTED
+  WiFi.mode(WIFI_AP);
+  WiFi.softAP("esp-captive");
+#endif
+
+  // curl -v http://192.168.4.1/get-or-post
+  // curl -v -X POST -d "a=b" http://192.168.4.1/get-or-post
+  server.on("/get-or-post", WebRequestMethod::HTTP_GET | WebRequestMethod::HTTP_POST, [](AsyncWebServerRequest *request) {
+    request->send(200, "text/plain", "Hello");
+  });
+
+  // curl -v http://192.168.4.1/any
+  server.on("/any", WebRequestMethod::HTTP_ANY, [](AsyncWebServerRequest *request) {
+    request->send(200, "text/plain", "Hello");
+  });
+
+  server.begin();
+}
+
+// not needed
+void loop() {
+  delay(100);
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,6 +14,8 @@ lib_dir = .
 ; src_dir = examples/Filters
 ; src_dir = examples/FlashResponse
 ; src_dir = examples/HeaderManipulation
+; src_dir = examples/Headers
+; src_dir = examples/HTTPMethods
 ; src_dir = examples/Json
 ; src_dir = examples/LargeResponse
 ; src_dir = examples/Logging
@@ -38,9 +40,9 @@ src_dir = examples/PerfTests
 ; src_dir = examples/UploadFlash
 ; src_dir = examples/URIMatcher
 ; src_dir = examples/URIMatcherTest
+; src_dir = examples/WebDAVMethods
 ; src_dir = examples/WebSocket
 ; src_dir = examples/WebSocketEasy
-; src_dir = examples/WebDAVMethods
 
 [env]
 framework = arduino


### PR DESCRIPTION
Adds an HTTPMethods example to show how to use asyncws in projects conflicting with arduino core enum (including HTTP_Method.h)

This example will also help verify further refactoring