### PR TITLE
Locking cleanup

### DIFF
--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -325,14 +325,12 @@ void AsyncWebSocketClient::_onAck(size_t len, uint32_t time) {
         _controlQueue.pop_front();
         _status = WS_DISCONNECTED;
         async_ws_log_v("[%s][%" PRIu32 "] ACK WS_DISCONNECTED", _server->url(), _clientId);
-        if (_client) {
-          /*
-            Unlocking has to be called before return execution otherwise std::unique_lock ::~unique_lock() will get an exception pthread_mutex_unlock.
-            Due to _client->close() shall call the callback function _onDisconnect()
-            The calling flow _onDisconnect() --> _handleDisconnect() --> ~AsyncWebSocketClient()
-          */
+        // Capture _client before unlocking: _client->close() triggers the _onDisconnect() --> _handleDisconnect() --> ~AsyncWebSocketClient() chain,
+        // so we must not access any member after unlock.
+        AsyncClient *c = _client;
+        if (c) {
           lock.unlock();
-          _client->close();
+          c->close();
         }
         return;
       }
@@ -472,17 +470,15 @@ bool AsyncWebSocketClient::_queueMessage(AsyncWebSocketSharedBuffer buffer, uint
     if (closeWhenFull) {
       _status = WS_DISCONNECTED;
 
-      if (_client) {
-        /*
-          Unlocking has to be called before return execution otherwise std::unique_lock ::~unique_lock() will get an exception pthread_mutex_unlock.
-          Due to _client->close() shall call the callback function _onDisconnect()
-          The calling flow _onDisconnect() --> _handleDisconnect() --> ~AsyncWebSocketClient()
-        */
-        lock.unlock();
-        _client->close();
-      }
-
       async_ws_log_w("[%s][%" PRIu32 "] Too many messages queued: closing connection", _server->url(), _clientId);
+
+      // Capture _client before unlocking: _client->close() triggers the _onDisconnect() --> _handleDisconnect() --> ~AsyncWebSocketClient() chain,
+      // so we must not access any member after unlock.
+      AsyncClient *c = _client;
+      if (c) {
+        lock.unlock();
+        c->close();
+      }
 
     } else {
       async_ws_log_w("[%s][%" PRIu32 "] Too many messages queued: discarding new message", _server->url(), _clientId);
@@ -531,8 +527,13 @@ void AsyncWebSocketClient::close(uint16_t code, const char *message) {
       return;
     } else {
       async_ws_log_e("Failed to allocate");
-      if (_client) {
-        _client->abort();
+      // Reads _client, then dereference it without any lock.
+      // A concurrent _onDisconnect could null + delete the client between the check and the use.
+      // Local capture ensures the pointer is read exactly once, eliminating the null-dereference.
+      // (TOCTOU)
+      AsyncClient *c = _client;
+      if (c) {
+        c->abort();
       }
     }
   }
@@ -548,17 +549,27 @@ void AsyncWebSocketClient::_onError(int8_t err) {
 }
 
 void AsyncWebSocketClient::_onTimeout(uint32_t time) {
-  if (!_client) {
+  // Reads _client, then dereference it without any lock.
+  // A concurrent _onDisconnect could null + delete the client between the check and the use.
+  // Local capture ensures the pointer is read exactly once, eliminating the null-dereference.
+  // (TOCTOU)
+  AsyncClient *c = _client;
+  if (!c) {
     return;
   }
   async_ws_log_v("[%s][%" PRIu32 "] TIMEOUT %" PRIu32, _server->url(), _clientId, time);
-  _client->close();
+  c->close();
 }
 
 void AsyncWebSocketClient::_onDisconnect() {
   async_ws_log_v("[%s][%" PRIu32 "] DISCONNECT", _server->url(), _clientId);
   _status = WS_DISCONNECTED;
-  _client = nullptr;
+  {
+    // Every queue method (_queueControl, _queueMessage, _runQueue, _onPoll, _onAck) reads _client while holding _queue_lock.
+    // For those guarded reads to be meaningful, the write must also be synchronized. This doesn't change _queue_lock's purpose — it still guards queue integrity — but ensures the "is client alive?" checks that protect queue operations see a consistent value.
+    asyncsrv::lock_guard_type lock(_queue_lock);
+    _client = nullptr;
+  }
   _server->_handleDisconnect(this);
 }
 
@@ -951,17 +962,27 @@ bool AsyncWebSocketClient::binary(const __FlashStringHelper *data, size_t len) {
 #endif
 
 IPAddress AsyncWebSocketClient::remoteIP() const {
-  if (!_client) {
+  // Reads _client, then dereference it without any lock.
+  // A concurrent _onDisconnect could null + delete the client between the check and the use.
+  // Local capture ensures the pointer is read exactly once, eliminating the null-dereference.
+  // (TOCTOU)
+  AsyncClient *c = _client;
+  if (!c) {
     return IPAddress((uint32_t)0U);
   }
-  return _client->remoteIP();
+  return c->remoteIP();
 }
 
 uint16_t AsyncWebSocketClient::remotePort() const {
-  if (!_client) {
+  // Reads _client, then dereference it without any lock.
+  // A concurrent _onDisconnect could null + delete the client between the check and the use.
+  // Local capture ensures the pointer is read exactly once, eliminating the null-dereference.
+  // (TOCTOU)
+  AsyncClient *c = _client;
+  if (!c) {
     return 0;
   }
-  return _client->remotePort();
+  return c->remotePort();
 }
 
 /*

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -531,7 +531,9 @@ void AsyncWebSocketClient::close(uint16_t code, const char *message) {
       return;
     } else {
       async_ws_log_e("Failed to allocate");
-      _client->abort();
+      if (_client) {
+        _client->abort();
+      }
     }
   }
   _queueControl(WS_DISCONNECT);

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -297,7 +297,7 @@ AsyncWebSocketClient::AsyncWebSocketClient(AsyncClient *client, AsyncWebSocket *
 
 AsyncWebSocketClient::~AsyncWebSocketClient() {
   {
-    asyncsrv::lock_guard_type lock(_lock);
+    asyncsrv::lock_guard_type lock(_queue_lock);
     _messageQueue.clear();
     _controlQueue.clear();
   }
@@ -313,7 +313,7 @@ void AsyncWebSocketClient::_clearQueue() {
 void AsyncWebSocketClient::_onAck(size_t len, uint32_t time) {
   _lastMessageTime = millis();
 
-  asyncsrv::unique_lock_type lock(_lock);
+  asyncsrv::unique_lock_type lock(_queue_lock);
 
   async_ws_log_v("[%s][%" PRIu32 "] START ACK(%u, %" PRIu32 ") Q:%u", _server->url(), _clientId, len, time, _messageQueue.size());
 
@@ -357,7 +357,7 @@ void AsyncWebSocketClient::_onAck(size_t len, uint32_t time) {
 }
 
 void AsyncWebSocketClient::_onPoll() {
-  asyncsrv::unique_lock_type lock(_lock);
+  asyncsrv::unique_lock_type lock(_queue_lock);
 
   if (!_client) {
     return;
@@ -430,22 +430,22 @@ void AsyncWebSocketClient::_runQueue() {
 }
 
 bool AsyncWebSocketClient::queueIsFull() const {
-  asyncsrv::lock_guard_type lock(_lock);
+  asyncsrv::lock_guard_type lock(_queue_lock);
   return (_messageQueue.size() >= WS_MAX_QUEUED_MESSAGES) || (_status != WS_CONNECTED);
 }
 
 size_t AsyncWebSocketClient::queueLen() const {
-  asyncsrv::lock_guard_type lock(_lock);
+  asyncsrv::lock_guard_type lock(_queue_lock);
   return _messageQueue.size();
 }
 
 bool AsyncWebSocketClient::canSend() const {
-  asyncsrv::lock_guard_type lock(_lock);
+  asyncsrv::lock_guard_type lock(_queue_lock);
   return _messageQueue.size() < WS_MAX_QUEUED_MESSAGES;
 }
 
 bool AsyncWebSocketClient::_queueControl(uint8_t opcode, const uint8_t *data, size_t len, bool mask) {
-  asyncsrv::lock_guard_type lock(_lock);
+  asyncsrv::lock_guard_type lock(_queue_lock);
 
   if (!_client) {
     return false;
@@ -462,7 +462,7 @@ bool AsyncWebSocketClient::_queueControl(uint8_t opcode, const uint8_t *data, si
 }
 
 bool AsyncWebSocketClient::_queueMessage(AsyncWebSocketSharedBuffer buffer, uint8_t opcode, bool mask) {
-  asyncsrv::unique_lock_type lock(_lock);
+  asyncsrv::unique_lock_type lock(_queue_lock);
 
   if (!_client || !buffer || buffer->empty() || _status != WS_CONNECTED) {
     return false;
@@ -546,7 +546,6 @@ void AsyncWebSocketClient::_onError(int8_t err) {
 }
 
 void AsyncWebSocketClient::_onTimeout(uint32_t time) {
-  asyncsrv::lock_guard_type lock(_lock);
   if (!_client) {
     return;
   }
@@ -555,7 +554,6 @@ void AsyncWebSocketClient::_onTimeout(uint32_t time) {
 }
 
 void AsyncWebSocketClient::_onDisconnect() {
-  asyncsrv::lock_guard_type lock(_lock);
   async_ws_log_v("[%s][%" PRIu32 "] DISCONNECT", _server->url(), _clientId);
   _status = WS_DISCONNECTED;
   _client = nullptr;
@@ -951,22 +949,16 @@ bool AsyncWebSocketClient::binary(const __FlashStringHelper *data, size_t len) {
 #endif
 
 IPAddress AsyncWebSocketClient::remoteIP() const {
-  asyncsrv::lock_guard_type lock(_lock);
-
   if (!_client) {
     return IPAddress((uint32_t)0U);
   }
-
   return _client->remoteIP();
 }
 
 uint16_t AsyncWebSocketClient::remotePort() const {
-  asyncsrv::lock_guard_type lock(_lock);
-
   if (!_client) {
     return 0;
   }
-
   return _client->remotePort();
 }
 

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -981,7 +981,7 @@ void AsyncWebSocket::_handleEvent(AsyncWebSocketClient *client, AwsEventType typ
 }
 
 AsyncWebSocketClient *AsyncWebSocket::_newClient(AsyncWebServerRequest *request) {
-  asyncsrv::lock_guard_type lock(_lock);
+  asyncsrv::lock_guard_type lock(_ws_clients_lock);
   _clients.emplace_back(request, this);
   // we've just detached AsyncTCP client from AsyncWebServerRequest
   _handleEvent(&_clients.back(), WS_EVT_CONNECT, request, NULL, 0);
@@ -991,7 +991,7 @@ AsyncWebSocketClient *AsyncWebSocket::_newClient(AsyncWebServerRequest *request)
 }
 
 void AsyncWebSocket::_handleDisconnect(AsyncWebSocketClient *client) {
-  asyncsrv::lock_guard_type lock(_lock);
+  asyncsrv::lock_guard_type lock(_ws_clients_lock);
   const auto client_id = client->id();
   const auto iter = std::find_if(std::begin(_clients), std::end(_clients), [client_id](const AsyncWebSocketClient &c) {
     return c.id() == client_id;
@@ -1002,14 +1002,14 @@ void AsyncWebSocket::_handleDisconnect(AsyncWebSocketClient *client) {
 }
 
 bool AsyncWebSocket::availableForWriteAll() {
-  asyncsrv::lock_guard_type lock(_lock);
+  asyncsrv::lock_guard_type lock(_ws_clients_lock);
   return std::none_of(std::begin(_clients), std::end(_clients), [](const AsyncWebSocketClient &c) {
     return c.queueIsFull();
   });
 }
 
 bool AsyncWebSocket::availableForWrite(uint32_t id) {
-  asyncsrv::lock_guard_type lock(_lock);
+  asyncsrv::lock_guard_type lock(_ws_clients_lock);
   const auto iter = std::find_if(std::begin(_clients), std::end(_clients), [id](const AsyncWebSocketClient &c) {
     return c.id() == id;
   });
@@ -1020,14 +1020,14 @@ bool AsyncWebSocket::availableForWrite(uint32_t id) {
 }
 
 size_t AsyncWebSocket::count() const {
-  asyncsrv::lock_guard_type lock(_lock);
+  asyncsrv::lock_guard_type lock(_ws_clients_lock);
   return std::count_if(std::begin(_clients), std::end(_clients), [](const AsyncWebSocketClient &c) {
     return c.status() == WS_CONNECTED;
   });
 }
 
 AsyncWebSocketClient *AsyncWebSocket::client(uint32_t id) {
-  asyncsrv::lock_guard_type lock(_lock);
+  asyncsrv::lock_guard_type lock(_ws_clients_lock);
   const auto iter = std::find_if(_clients.begin(), _clients.end(), [id](const AsyncWebSocketClient &c) {
     return c.id() == id && c.status() == WS_CONNECTED;
   });
@@ -1039,14 +1039,14 @@ AsyncWebSocketClient *AsyncWebSocket::client(uint32_t id) {
 }
 
 void AsyncWebSocket::close(uint32_t id, uint16_t code, const char *message) {
-  asyncsrv::lock_guard_type lock(_lock);
+  asyncsrv::lock_guard_type lock(_ws_clients_lock);
   if (AsyncWebSocketClient *c = client(id)) {
     c->close(code, message);
   }
 }
 
 void AsyncWebSocket::closeAll(uint16_t code, const char *message) {
-  asyncsrv::lock_guard_type lock(_lock);
+  asyncsrv::lock_guard_type lock(_ws_clients_lock);
   for (auto &c : _clients) {
     if (c.status() == WS_CONNECTED) {
       c.close(code, message);
@@ -1055,7 +1055,7 @@ void AsyncWebSocket::closeAll(uint16_t code, const char *message) {
 }
 
 void AsyncWebSocket::cleanupClients(uint16_t maxClients) {
-  asyncsrv::lock_guard_type lock(_lock);
+  asyncsrv::lock_guard_type lock(_ws_clients_lock);
   const size_t c = count();
   if (c > maxClients) {
     async_ws_log_v("[%s] CLEANUP %" PRIu32 " (%u/%" PRIu16 ")", _url.c_str(), _clients.front().id(), c, maxClients);
@@ -1071,13 +1071,13 @@ void AsyncWebSocket::cleanupClients(uint16_t maxClients) {
 }
 
 bool AsyncWebSocket::ping(uint32_t id, const uint8_t *data, size_t len) {
-  asyncsrv::lock_guard_type lock(_lock);
+  asyncsrv::lock_guard_type lock(_ws_clients_lock);
   AsyncWebSocketClient *c = client(id);
   return c && c->ping(data, len);
 }
 
 AsyncWebSocket::SendStatus AsyncWebSocket::pingAll(const uint8_t *data, size_t len) {
-  asyncsrv::lock_guard_type lock(_lock);
+  asyncsrv::lock_guard_type lock(_ws_clients_lock);
   size_t hit = 0;
   size_t miss = 0;
   for (auto &c : _clients) {
@@ -1091,7 +1091,7 @@ AsyncWebSocket::SendStatus AsyncWebSocket::pingAll(const uint8_t *data, size_t l
 }
 
 bool AsyncWebSocket::text(uint32_t id, const uint8_t *message, size_t len) {
-  asyncsrv::lock_guard_type lock(_lock);
+  asyncsrv::lock_guard_type lock(_ws_clients_lock);
   AsyncWebSocketClient *c = client(id);
   return c && c->text(makeSharedBuffer(message, len));
 }
@@ -1138,7 +1138,7 @@ bool AsyncWebSocket::text(uint32_t id, AsyncWebSocketMessageBuffer *buffer) {
   return enqueued;
 }
 bool AsyncWebSocket::text(uint32_t id, AsyncWebSocketSharedBuffer buffer) {
-  asyncsrv::lock_guard_type lock(_lock);
+  asyncsrv::lock_guard_type lock(_ws_clients_lock);
   AsyncWebSocketClient *c = client(id);
   return c && c->text(buffer);
 }
@@ -1188,7 +1188,7 @@ AsyncWebSocket::SendStatus AsyncWebSocket::textAll(AsyncWebSocketMessageBuffer *
 }
 
 AsyncWebSocket::SendStatus AsyncWebSocket::textAll(AsyncWebSocketSharedBuffer buffer) {
-  asyncsrv::lock_guard_type lock(_lock);
+  asyncsrv::lock_guard_type lock(_ws_clients_lock);
   size_t hit = 0;
   size_t miss = 0;
   for (auto &c : _clients) {
@@ -1202,7 +1202,7 @@ AsyncWebSocket::SendStatus AsyncWebSocket::textAll(AsyncWebSocketSharedBuffer bu
 }
 
 bool AsyncWebSocket::binary(uint32_t id, const uint8_t *message, size_t len) {
-  asyncsrv::lock_guard_type lock(_lock);
+  asyncsrv::lock_guard_type lock(_ws_clients_lock);
   AsyncWebSocketClient *c = client(id);
   return c && c->binary(makeSharedBuffer(message, len));
 }
@@ -1239,7 +1239,7 @@ bool AsyncWebSocket::binary(uint32_t id, AsyncWebSocketMessageBuffer *buffer) {
   return enqueued;
 }
 bool AsyncWebSocket::binary(uint32_t id, AsyncWebSocketSharedBuffer buffer) {
-  asyncsrv::lock_guard_type lock(_lock);
+  asyncsrv::lock_guard_type lock(_ws_clients_lock);
   AsyncWebSocketClient *c = client(id);
   return c && c->binary(buffer);
 }
@@ -1280,7 +1280,7 @@ AsyncWebSocket::SendStatus AsyncWebSocket::binaryAll(AsyncWebSocketMessageBuffer
   return status;
 }
 AsyncWebSocket::SendStatus AsyncWebSocket::binaryAll(AsyncWebSocketSharedBuffer buffer) {
-  asyncsrv::lock_guard_type lock(_lock);
+  asyncsrv::lock_guard_type lock(_ws_clients_lock);
   size_t hit = 0;
   size_t miss = 0;
   for (auto &c : _clients) {

--- a/src/AsyncWebSocket.h
+++ b/src/AsyncWebSocket.h
@@ -222,7 +222,7 @@ private:
   uint8_t _pstate;
   uint32_t _lastMessageTime;
   uint32_t _keepAlivePeriod;
-  mutable asyncsrv::mutex_type _lock;
+  mutable asyncsrv::mutex_type _queue_lock;
   std::deque<AsyncWebSocketControl> _controlQueue;
   std::deque<AsyncWebSocketMessage> _messageQueue;
   bool closeWhenFull = true;
@@ -303,7 +303,6 @@ public:
   uint16_t remotePort() const;
 
   bool shouldBeDeleted() const {
-    asyncsrv::lock_guard_type lock(_lock);
     return !_client;
   }
 
@@ -371,7 +370,7 @@ private:
   AwsEventHandler _eventHandler;
   AwsHandshakeHandler _handshakeHandler;
   bool _enabled;
-  mutable asyncsrv::mutex_type _lock;
+  mutable asyncsrv::mutex_type _ws_clients_lock;
 
 public:
   typedef enum {


### PR DESCRIPTION
Renamed the _lock variables to a better name to match what they guard exactly.

_queue_lock is a lock guarding the queues and should not be used to guard the internal client pointer.

This is a fix of PR #427 and commit 085f27806ddc6b72b8598dc1ad494e7c7f869e12