### PR TITLE
fix(ws): Fully handle websocket frame tearing (closes #453)

### DIFF
--- a/examples/arduino/WebSocket/WebSocket.ino
+++ b/examples/arduino/WebSocket/WebSocket.ino
@@ -19,6 +19,10 @@
 
 #include <ESPAsyncWebServer.h>
 
+#include <algorithm>
+#include <memory>
+#include <vector>
+
 static const char *htmlContent PROGMEM = R"(
 <!DOCTYPE html>
 <html>
@@ -63,12 +67,55 @@ static const size_t htmlContentLength = strlen_P(htmlContent);
 static AsyncWebServer server(80);
 static AsyncWebSocket ws("/ws");
 
+//
+// Masked-broadcast test: sends one AsyncWebSocketSharedBuffer to every connected client, each
+// with its own random mask key.  Validates that masking a shared buffer for one client can't
+// affect what any other client (sharing that same buffer) sends or receives.
+//
+// Triggered by sending the text command "masktest" (optionally "masktest <len>") over an
+// already-open WS connection (see the WS_EVT_DATA handler below). The payload is deterministic
+// (a seq/len header + a repeating 0-9 filler)The decoded payload must be byte-identical for all
+// clients despite each seeing different bytes on the wire.
+//
+// RFC 6455 5.1 forbids the server from masking frames it sends, and requires a compliant client
+// to close the connection on receipt of one.  This test deliberately violates that rule, so it
+// requires a client that tolerates reading masked frames from the server (e.g. websocat4).
+//
+static void fillMaskTestPayload(std::vector<uint8_t> &out, size_t len) {
+  char header[48];
+  const int written = snprintf(header, sizeof(header), "MASKTEST len=%u\n", (unsigned)len);
+  // snprintf's return value can exceed sizeof(header) if truncated; clamp to what's actually in the buffer
+  const size_t headerLen = std::min((size_t)std::max(written, 0), sizeof(header));
+  out.resize(len);
+  const size_t n = std::min(headerLen, len);
+  memcpy(out.data(), header, n);
+  for (size_t i = n; i < len; i++) {
+    out[i] = '0' + ((i - n) % 10);
+  }
+}
+
+// Sends `len` bytes of deterministic content to every connected client as an individually
+// masked TEXT frame, reusing one shared buffer across all of them. Returns the number of
+// clients the frame was successfully enqueued for.
+static size_t sendMaskedBroadcast(size_t len) {
+  std::shared_ptr<std::vector<uint8_t>> buffer = std::make_shared<std::vector<uint8_t>>();
+  fillMaskTestPayload(*buffer, len);
+  size_t sent = 0;
+  for (auto &client : ws.getClients()) {
+    if (client.status() == WS_CONNECTED && client.message(buffer, WS_TEXT, /*mask=*/true)) {
+      sent++;
+    }
+  }
+  Serial.printf("[masktest] len=%u sent to %u client(s), buffer use_count=%ld\n", (unsigned)len, (unsigned)sent, (long)buffer.use_count());
+  return sent;
+}
+
 void setup() {
   Serial.begin(115200);
 
 #if ASYNCWEBSERVER_WIFI_SUPPORTED
   WiFi.mode(WIFI_AP);
-  WiFi.softAP("esp-captive");
+  WiFi.softAP("esp-captive", nullptr, 11);
 #endif
 
   // serves root html page
@@ -86,6 +133,11 @@ void setup() {
   //
   // Generates 2001 characters (\n at the end) to cause a fragmentation (over TCP MSS):
   // > openssl rand -hex 1000 | websocat ws://192.168.4.1/ws
+  //
+  // Triggers the masked-broadcast test (see sendMaskedBroadcast() above).
+  // This requires a client that tolerates reading masked frames from the server (e.g. websocat4),
+  // since it's a deliberate RFC 6455 5.1 violation when used this way.
+  // > echo "masktest 4000" | websocat4 --ws-ignore-invalid-masks ws://192.168.4.1/ws
   //
   ws.onEvent([](AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventType type, void *arg, uint8_t *data, size_t len) {
     (void)len;
@@ -123,8 +175,18 @@ void setup() {
         if (info->message_opcode == WS_TEXT) {
           Serial.printf("ws text: %s\n", (char *)data);
           client->ping();
-          // Also send a message in the message queue when we get one
-          ws.textAll("Message received: " + String((char *)data));
+
+          if (strncmp((char *)data, "masktest", 8) == 0) {
+            size_t maskLen = 2000;
+            unsigned long parsed = strtoul((char *)data + 8, nullptr, 10);
+            if (parsed > 0) {
+              maskLen = std::min((size_t)parsed, (size_t)65000);  // stay within a single (non-fragmented) WS frame
+            }
+            sendMaskedBroadcast(maskLen);
+          } else {
+            // Also send a message in the message queue when we get one
+            ws.textAll("Message received: " + String((char *)data));
+          }
         }
 
       } else {

--- a/examples/arduino/WebSocket/WebSocket.ino
+++ b/examples/arduino/WebSocket/WebSocket.ino
@@ -103,8 +103,14 @@ void setup() {
       Serial.println("ws error");
 
     } else if (type == WS_EVT_PONG) {
-      Serial.println("ws pong");
-
+      if (len == sizeof(uint32_t)) {
+        uint32_t pongTime;
+        memcpy(&pongTime, data, sizeof(pongTime));
+        uint32_t pingDuration = micros() - pongTime;
+        Serial.printf("ws[%" PRIu32 "] pong [%" PRIu32 "] duration: %" PRIu32 " us\n", client->id(), pongTime, pingDuration);
+      } else {
+        Serial.printf("ws[%" PRIu32 "] pong [%u]\n", client->id(), len);
+      }
     } else if (type == WS_EVT_DATA) {
       AwsFrameInfo *info = (AwsFrameInfo *)arg;
       Serial.printf(
@@ -205,8 +211,10 @@ void loop() {
     ws.textAll(random);
 
     // ping twice (2 control frames)
-    ws.pingAll();
-    ws.pingAll();
+    uint32_t pingTime = micros();
+    ws.pingAll((const uint8_t *)&pingTime, sizeof(pingTime));
+    pingTime = micros();
+    ws.pingAll((const uint8_t *)&pingTime, sizeof(pingTime));
 
 #ifdef ESP32
     Serial.printf("Uptime: %3lu s, Free heap: %" PRIu32 ", Min free heap: %" PRIu32 "\n", millis() / 1000, ESP.getFreeHeap(), ESP.getMinFreeHeap());

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -60,7 +60,7 @@ static size_t webSocketSendFrameWindow(AsyncClient *client) {
 // function of RFC 6455 framing rules, cheap enough to recompute on demand
 // rather than cache
 static uint8_t webSocketFrameHeaderLen(size_t payloadLen, bool mask) {
-  return 2 + ((payloadLen && mask) ? 4 : 0) + ((payloadLen > 125) ? 2 : 0);
+  return 2 + (mask ? 4 : 0) + ((payloadLen > 125) ? 2 : 0);
 }
 
 // Commits any not-yet-committed bytes of one WS frame (header+payload) to
@@ -90,7 +90,7 @@ static size_t
       hdr[2] = (uint8_t)((len >> 8) & 0xFF);
       hdr[3] = (uint8_t)(len & 0xFF);
     }
-    if (len && mask) {
+    if (mask) {
       hdr[1] |= 0x80;
       memcpy(hdr + (headLen - 4), maskKey, 4);
     }

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -63,6 +63,9 @@ static uint8_t webSocketFrameHeaderLen(size_t payloadLen, bool mask) {
   return 2 + (mask ? 4 : 0) + ((payloadLen > 125) ? 2 : 0);
 }
 
+// Stack-allocated chunk size for masking payload data
+static constexpr size_t WS_MASK_CHUNK_SIZE = 128;
+
 // Commits any not-yet-committed bytes of one WS frame (header+payload) to
 // the client, resuming from `frameSent` bytes already committed by a prior
 // call for this exact frame. final/opcode/mask/maskKey/data/len must stay
@@ -72,7 +75,7 @@ static uint8_t webSocketFrameHeaderLen(size_t payloadLen, bool mask) {
 // never assumes an add() fully succeeds, since some AsyncClient backends
 // (e.g. SSL) can commit a genuine partial amount.
 static size_t
-  webSocketAddFrame(AsyncClient *client, bool final, uint8_t opcode, bool mask, const uint8_t maskKey[4], uint8_t *data, size_t len, size_t frameSent) {
+  webSocketAddFrame(AsyncClient *client, bool final, uint8_t opcode, bool mask, const uint8_t maskKey[4], const uint8_t *data, size_t len, size_t frameSent) {
   if (!client || !client->canSend()) {
     return 0;
   }
@@ -95,7 +98,7 @@ static size_t
       memcpy(hdr + (headLen - 4), maskKey, 4);
     }
 
-    size_t added = client->add((const char *)(hdr + frameSent), headLen - frameSent);
+    size_t added = client->add((const char *)(hdr + frameSent), headLen - frameSent, ASYNC_WRITE_FLAG_COPY | ((len > 0) ? ASYNC_WRITE_FLAG_MORE : 0));
     committed += added;
     frameSent += added;
     if (frameSent < headLen) {
@@ -103,22 +106,29 @@ static size_t
     }
   }
 
-  const size_t payloadSent = frameSent - headLen;
+  size_t payloadSent = frameSent - headLen;
   if (payloadSent < len) {
-    const size_t remaining = len - payloadSent;
+    size_t remaining = len - payloadSent;
     if (mask) {
-      for (size_t i = 0; i < remaining; i++) {
-        data[payloadSent + i] ^= maskKey[(payloadSent + i) % 4];
+      // The data buffer is shared, but each client masks with its own random key.
+      // Mask in to a scratch buffer one chunk at a time to avoid malloc overhead.
+      uint8_t masked_data[WS_MASK_CHUNK_SIZE];
+      while (remaining > 0) {
+        const size_t chunk = std::min(remaining, sizeof(masked_data));
+        for (size_t i = 0; i < chunk; i++) {
+          masked_data[i] = data[payloadSent + i] ^ maskKey[(payloadSent + i) % 4];
+        }
+        const size_t added = client->add((const char *)masked_data, chunk, ASYNC_WRITE_FLAG_COPY | ((chunk == remaining) ? 0 : ASYNC_WRITE_FLAG_MORE));
+        committed += added;
+        if (added < chunk) {
+          break;  // out of space (or partial commit) -- resume here next time
+        }
+        payloadSent += added;
+        remaining -= added;
       }
+    } else {
+      committed += client->add((const char *)(data + payloadSent), remaining, ASYNC_WRITE_FLAG_COPY);
     }
-    size_t added = client->add((const char *)(data + payloadSent), remaining);
-    if (mask && added < remaining) {
-      // undo masking of the unsent tail so a retry masks it correctly from the new offset
-      for (size_t i = added; i < remaining; i++) {
-        data[payloadSent + i] ^= maskKey[(payloadSent + i) % 4];
-      }
-    }
-    committed += added;
   }
 
   return committed;

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -640,7 +640,7 @@ void AsyncWebSocketClient::_onData(void *pbuf, size_t plen) {
       } else if (_pinfo.opcode == WS_PONG) {
         async_ws_log_v("[%s][%" PRIu32 "] DATA PONG", _server->url(), _clientId);
         if (datalen != AWSC_PING_PAYLOAD_LEN || memcmp(AWSC_PING_PAYLOAD, data, AWSC_PING_PAYLOAD_LEN) != 0) {
-          _server->_handleEvent(this, WS_EVT_PONG, NULL, NULL, 0);
+          _server->_handleEvent(this, WS_EVT_PONG, NULL, data, datalen);
         }
 
       } else if (_pinfo.opcode < WS_DISCONNECT) {  // continuation or text/binary frame

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -267,7 +267,7 @@ void AsyncWebSocketClient::_runQueue(asyncsrv::unique_lock_type &lock) {
       } else {
         const size_t window = webSocketSendFrameWindow(_client);
         if (!window) {
-          return;
+          break;  // no space to send right now
         }
         const size_t remaining = target.size() - _sent;
         _framePayloadLen = std::min(remaining, window);

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -45,7 +45,7 @@ AsyncWebSocketSharedBuffer makeSharedBuffer(const uint8_t *message, size_t len) 
 }
 }  // namespace
 
-size_t webSocketSendFrameWindow(AsyncClient *client) {
+static size_t webSocketSendFrameWindow(AsyncClient *client) {
   if (!client || !client->canSend()) {
     return 0;
   }
@@ -59,7 +59,7 @@ size_t webSocketSendFrameWindow(AsyncClient *client) {
 // wire header length for a frame with this payload length/masking -- pure
 // function of RFC 6455 framing rules, cheap enough to recompute on demand
 // rather than cache
-uint8_t webSocketFrameHeaderLen(size_t payloadLen, bool mask) {
+static uint8_t webSocketFrameHeaderLen(size_t payloadLen, bool mask) {
   return 2 + ((payloadLen && mask) ? 4 : 0) + ((payloadLen > 125) ? 2 : 0);
 }
 
@@ -71,29 +71,30 @@ uint8_t webSocketFrameHeaderLen(size_t payloadLen, bool mask) {
 // the number of *additional* bytes committed by this call (0 if none);
 // never assumes an add() fully succeeds, since some AsyncClient backends
 // (e.g. SSL) can commit a genuine partial amount.
-size_t webSocketAddFrame(AsyncClient *client, bool final, uint8_t opcode, bool mask, const uint8_t maskKey[4], uint8_t *data, size_t len, size_t frameSent) {
+static size_t
+  webSocketAddFrame(AsyncClient *client, bool final, uint8_t opcode, bool mask, const uint8_t maskKey[4], uint8_t *data, size_t len, size_t frameSent) {
   if (!client || !client->canSend()) {
     return 0;
   }
 
-  const uint8_t headLen = webSocketFrameHeaderLen(len, mask);
-  uint8_t hdr[8] = {0, 0, 0, 0, 0, 0, 0, 0};
-  hdr[0] = (opcode & 0x0F) | (final ? 0x80 : 0);
-  if (len < 126) {
-    hdr[1] = len & 0x7F;
-  } else {
-    hdr[1] = 126;
-    hdr[2] = (uint8_t)((len >> 8) & 0xFF);
-    hdr[3] = (uint8_t)(len & 0xFF);
-  }
-  if (len && mask) {
-    hdr[1] |= 0x80;
-    memcpy(hdr + (headLen - 4), maskKey, 4);
-  }
-
   size_t committed = 0;
 
+  const uint8_t headLen = webSocketFrameHeaderLen(len, mask);
   if (frameSent < headLen) {
+    uint8_t hdr[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    hdr[0] = (opcode & 0x0F) | (final ? 0x80 : 0);
+    if (len < 126) {
+      hdr[1] = len & 0x7F;
+    } else {
+      hdr[1] = 126;
+      hdr[2] = (uint8_t)((len >> 8) & 0xFF);
+      hdr[3] = (uint8_t)(len & 0xFF);
+    }
+    if (len && mask) {
+      hdr[1] |= 0x80;
+      memcpy(hdr + (headLen - 4), maskKey, 4);
+    }
+
     size_t added = client->add((const char *)(hdr + frameSent), headLen - frameSent);
     committed += added;
     frameSent += added;
@@ -220,37 +221,11 @@ void AsyncWebSocketClient::_onAck(size_t len, uint32_t time) {
 
   asyncsrv::unique_lock_type lock(_queue_lock);
 
-  async_ws_log_v("[%s][%" PRIu32 "] ACK(%u) unacked:%u", _server->url(), _clientId, len, _unacked);
+  async_ws_log_v("[%s][%" PRIu32 "] ACK(%u)", _server->url(), _clientId, len);
 
-  // exactly one frame can ever be outstanding, so a single clamped
-  // subtraction is all the ack accounting this needs
-  const bool wasAwaitingAck = (_frameSent == 0 && _unacked > 0);
-  _unacked -= std::min(len, _unacked);
-
-  if (wasAwaitingAck && _unacked == 0) {
-    // the in-flight frame is now fully sent and fully acked
-    if (_sendingControl && !_controlQueue.empty()) {
-      const uint8_t opcode = _controlQueue.front().opcode();
-      _controlQueue.pop_front();
-      if (_status == WS_DISCONNECTING && opcode == WS_DISCONNECT) {
-        _status = WS_DISCONNECTED;
-        async_ws_log_v("[%s][%" PRIu32 "] ACK WS_DISCONNECTED", _server->url(), _clientId);
-        // Capture _client before unlocking: _client->close() triggers the _onDisconnect() --> _handleDisconnect() --> ~AsyncWebSocketClient() chain,
-        // so we must not access any member after unlock.
-        AsyncClient *c = _client;
-        if (c) {
-          lock.unlock();
-          c->close();
-        }
-        return;
-      }
-    } else if (!_sendingControl && !_messageQueue.empty() && _sent >= _messageQueue.front().size()) {
-      _messageQueue.pop_front();
-      _sent = 0;
-    }
-  }
-
-  _runQueue();
+  // Messages are dequeued as soon as they're fully add()'ed, not on ack --
+  // an ack only ever matters here as a sign that space() may have grown.
+  _runQueue(lock);
 }
 
 void AsyncWebSocketClient::_onPoll() {
@@ -261,77 +236,105 @@ void AsyncWebSocketClient::_onPoll() {
   }
 
   if (_client && _client->canSend() && (!_controlQueue.empty() || !_messageQueue.empty())) {
-    _runQueue();
+    _runQueue(lock);
   } else if (_keepAlivePeriod > 0 && (millis() - _lastMessageTime) >= _keepAlivePeriod && (_controlQueue.empty() && _messageQueue.empty())) {
     lock.unlock();
     ping((uint8_t *)AWSC_PING_PAYLOAD, AWSC_PING_PAYLOAD_LEN);
   }
 }
 
-void AsyncWebSocketClient::_runQueue() {
-  // all calls to this method MUST be protected by a mutex lock!
+void AsyncWebSocketClient::_runQueue(asyncsrv::unique_lock_type &lock) {
+  // all calls to this method MUST be protected by a mutex lock, passed in as `lock`
   if (!_client) {
     return;
   }
 
-  if (_frameSent == 0) {
-    if (_unacked > 0) {
-      return;  // waiting for the in-flight frame to be acked before starting the next one
-    }
+  bool needs_send = false;
+  while (true) {
+    if (_frameSent == 0) {
+      // idle: pick the next target by priority (control first)
+      if (!_controlQueue.empty()) {
+        _sendingControl = true;
+      } else if (!_messageQueue.empty()) {
+        _sendingControl = false;
+      } else {
+        break;  // nothing queued
+      }
 
-    // idle: pick the next target by priority (control first)
-    if (!_controlQueue.empty()) {
-      _sendingControl = true;
-    } else if (!_messageQueue.empty()) {
-      _sendingControl = false;
-    } else {
-      return;  // nothing queued
+      AsyncWebSocketMessage &target = _sendingControl ? _controlQueue.front() : _messageQueue.front();
+      if (_sendingControl) {
+        _framePayloadLen = target.size();
+      } else {
+        const size_t window = webSocketSendFrameWindow(_client);
+        if (!window) {
+          return;
+        }
+        const size_t remaining = target.size() - _sent;
+        _framePayloadLen = std::min(remaining, window);
+      }
+      if (target.mask()) {
+        _maskKey[0] = rand() % 0xFF;  // NOLINT(runtime/threadsafe_fn)
+        _maskKey[1] = rand() % 0xFF;  // NOLINT(runtime/threadsafe_fn)
+        _maskKey[2] = rand() % 0xFF;  // NOLINT(runtime/threadsafe_fn)
+        _maskKey[3] = rand() % 0xFF;  // NOLINT(runtime/threadsafe_fn)
+      }
     }
 
     AsyncWebSocketMessage &target = _sendingControl ? _controlQueue.front() : _messageQueue.front();
-    const size_t remaining = target.size() - (_sendingControl ? 0 : _sent);
+    const bool final = _sendingControl || (_sent + _framePayloadLen == target.size());
+    const uint8_t frameOpcode = (_sendingControl || _sent == 0) ? target.opcode() : (uint8_t)WS_CONTINUATION;
+    uint8_t *payload = target.data() + (_sendingControl ? 0 : _sent);
+
+    const size_t added = webSocketAddFrame(_client, final, frameOpcode, target.mask(), _maskKey, payload, _framePayloadLen, _frameSent);
+
+    async_ws_log_v(
+      "[%s][%" PRIu32 "][%" PRIu8 "] SEND ctrl:%d %u/%u added %u", _server->url(), _clientId, frameOpcode, _sendingControl, _frameSent,
+      webSocketFrameHeaderLen(_framePayloadLen, target.mask()) + _framePayloadLen, added
+    );
+
+    _frameSent += added;
+    needs_send |= (added > 0);
+
+    const size_t frameLen = webSocketFrameHeaderLen(_framePayloadLen, target.mask()) + _framePayloadLen;
+    if (_frameSent < frameLen) {
+      break;  // stalled; resume on the next trigger
+    }
+
+    // frame fully committed to TCP -- done with it, regardless of ack
+    _frameSent = 0;
+    const size_t framePayloadLen = _framePayloadLen;
+    _framePayloadLen = 0;
+
     if (_sendingControl) {
-      _framePayloadLen = remaining;
-    } else {
-      const size_t window = webSocketSendFrameWindow(_client);
-      if (!window) {
+      const uint8_t opcode = target.opcode();
+      _controlQueue.pop_front();
+      if (opcode == WS_DISCONNECT && _status == WS_DISCONNECTING) {
+        _status = WS_DISCONNECTED;
+        async_ws_log_v("[%s][%" PRIu32 "] DISCONNECT SENT", _server->url(), _clientId);
+        // Capture _client before unlocking: close() may synchronously run
+        // _onDisconnect() -> AsyncWebSocket::_handleDisconnect() -> list::erase(),
+        // destroying *this -- nothing after unlock() may touch any member.
+        // close() itself (not abort()) hands the pcb to lwIP's graceful
+        // close, which flushes/retransmits already-add()'ed data (this
+        // close frame included) independent of our lifetime from here on.
+        AsyncClient *c = _client;
+        lock.unlock();
+        c->send();  // Needed on some backends (e.g. SSL) to flush the close frame out before closing
+        c->close();
         return;
       }
-      _framePayloadLen = std::min(remaining, window);
+    } else {
+      _sent += framePayloadLen;
+      if (_sent >= target.size()) {
+        _messageQueue.pop_front();
+        _sent = 0;
+      }
     }
-    if (target.mask()) {
-      _maskKey[0] = rand() % 0xFF;  // NOLINT(runtime/threadsafe_fn)
-      _maskKey[1] = rand() % 0xFF;  // NOLINT(runtime/threadsafe_fn)
-      _maskKey[2] = rand() % 0xFF;  // NOLINT(runtime/threadsafe_fn)
-      _maskKey[3] = rand() % 0xFF;  // NOLINT(runtime/threadsafe_fn)
-    }
   }
 
-  AsyncWebSocketMessage &target = _sendingControl ? _controlQueue.front() : _messageQueue.front();
-  const bool final = _sendingControl || (_sent + _framePayloadLen == target.size());
-  const uint8_t frameOpcode = (_sendingControl || _sent == 0) ? target.opcode() : (uint8_t)WS_CONTINUATION;
-  uint8_t *payload = target.data() + (_sendingControl ? 0 : _sent);
-
-  async_ws_log_v(
-    "[%s][%" PRIu32 "][%" PRIu8 "] SEND ctrl:%d %u/%u", _server->url(), _clientId, frameOpcode, _sendingControl, _frameSent,
-    webSocketFrameHeaderLen(_framePayloadLen, target.mask()) + _framePayloadLen
-  );
-
-  _frameSent += webSocketAddFrame(_client, final, frameOpcode, target.mask(), _maskKey, payload, _framePayloadLen, _frameSent);
-
-  const size_t frameLen = webSocketFrameHeaderLen(_framePayloadLen, target.mask()) + _framePayloadLen;
-  if (_frameSent < frameLen) {
-    return;  // partial; resume on the next trigger
+  if (needs_send) {
+    _client->send();
   }
-
-  // frame fully committed to TCP -- now waiting for ack
-  _unacked = _frameSent;
-  _frameSent = 0;
-  if (!_sendingControl) {
-    _sent += _framePayloadLen;
-  }
-  _framePayloadLen = 0;
-  _client->send();
 }
 
 bool AsyncWebSocketClient::queueIsFull() const {
@@ -350,7 +353,7 @@ bool AsyncWebSocketClient::canSend() const {
 }
 
 bool AsyncWebSocketClient::_queueControl(uint8_t opcode, const uint8_t *data, size_t len, bool mask) {
-  asyncsrv::lock_guard_type lock(_queue_lock);
+  asyncsrv::unique_lock_type lock(_queue_lock);
 
   if (!_client) {
     return false;
@@ -361,12 +364,12 @@ bool AsyncWebSocketClient::_queueControl(uint8_t opcode, const uint8_t *data, si
   } else if (len > 125) {
     len = 125;
   }
-  AsyncWebSocketSharedBuffer buffer = len ? makeSharedBuffer(data, len) : std::make_shared<std::vector<uint8_t>>();
+  AsyncWebSocketSharedBuffer buffer = len ? makeSharedBuffer(data, len) : AsyncWebSocketSharedBuffer{};
   _controlQueue.emplace_back(buffer, opcode, len && mask);
   async_ws_log_v("[%s][%" PRIu32 "] QUEUE CTRL (%u) << %" PRIu8, _server->url(), _clientId, _controlQueue.size(), opcode);
 
   if (_client && _client->canSend()) {
-    _runQueue();
+    _runQueue(lock);
   }
 
   return true;
@@ -404,7 +407,7 @@ bool AsyncWebSocketClient::_queueMessage(AsyncWebSocketSharedBuffer buffer, uint
   async_ws_log_v("[%s][%" PRIu32 "] QUEUE MSG (%u/%u) << %" PRIu8, _server->url(), _clientId, _messageQueue.size(), WS_MAX_QUEUED_MESSAGES, opcode);
 
   if (_client && _client->canSend()) {
-    _runQueue();
+    _runQueue(lock);
   }
 
   return true;

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -37,6 +37,14 @@
 
 using namespace asyncsrv;
 
+namespace {
+AsyncWebSocketSharedBuffer makeSharedBuffer(const uint8_t *message, size_t len) {
+  auto buffer = std::make_shared<std::vector<uint8_t>>(len);
+  std::memcpy(buffer->data(), message, len);
+  return buffer;
+}
+}  // namespace
+
 size_t webSocketSendFrameWindow(AsyncClient *client) {
   if (!client || !client->canSend()) {
     return 0;
@@ -132,11 +140,6 @@ size_t webSocketSendFrame(AsyncClient *client, bool final, uint8_t opcode, bool 
   return len;
 }
 
-size_t AsyncWebSocketControl::send(AsyncClient *client) {
-  _finished = true;
-  return webSocketSendFrame(client, true, _opcode & 0x0F, _mask, _data, _len);
-}
-
 /*
  *    AsyncWebSocketMessageBuffer
  */
@@ -168,7 +171,7 @@ bool AsyncWebSocketMessageBuffer::reserve(size_t size) {
  */
 
 AsyncWebSocketMessage::AsyncWebSocketMessage(AsyncWebSocketSharedBuffer buffer, uint8_t opcode, bool mask)
-  : _WSbuffer{buffer}, _opcode(opcode & 0x07), _mask{mask}, _status{_WSbuffer ? WS_MSG_SENDING : WS_MSG_ERROR} {}
+  : _WSbuffer{buffer}, _opcode(opcode & 0x0F), _mask{mask}, _status{_WSbuffer ? WS_MSG_SENDING : WS_MSG_ERROR} {}
 
 size_t AsyncWebSocketMessage::ack(size_t len, uint32_t time) {
   (void)time;
@@ -186,6 +189,12 @@ size_t AsyncWebSocketMessage::send(AsyncClient *client) {
   if (!client) {
     async_ws_log_v("No client");
     return 0;
+  }
+
+  if (isControl()) {
+    // control frames are always a single, unfragmented frame
+    _status = WS_MSG_SENT;
+    return webSocketSendFrame(client, true, _opcode, _mask, (uint8_t *)_WSbuffer->data(), _WSbuffer->size());
   }
 
   if (_status != WS_MSG_SENDING) {
@@ -449,7 +458,13 @@ bool AsyncWebSocketClient::_queueControl(uint8_t opcode, const uint8_t *data, si
     return false;
   }
 
-  _controlQueue.emplace_back(opcode, data, len, mask);
+  if (!data) {
+    len = 0;
+  } else if (len > 125) {
+    len = 125;
+  }
+  AsyncWebSocketSharedBuffer buffer = len ? makeSharedBuffer(data, len) : std::make_shared<std::vector<uint8_t>>();
+  _controlQueue.emplace_back(buffer, opcode, len && mask);
   async_ws_log_v("[%s][%" PRIu32 "] QUEUE CTRL (%u) << %" PRIu8, _server->url(), _clientId, _controlQueue.size(), opcode);
 
   if (_client && _client->canSend()) {
@@ -865,14 +880,6 @@ size_t AsyncWebSocketClient::printf_P(PGM_P formatP, ...) {
   return enqueued ? len : 0;
 }
 #endif
-
-namespace {
-AsyncWebSocketSharedBuffer makeSharedBuffer(const uint8_t *message, size_t len) {
-  auto buffer = std::make_shared<std::vector<uint8_t>>(len);
-  std::memcpy(buffer->data(), message, len);
-  return buffer;
-}
-}  // namespace
 
 bool AsyncWebSocketClient::text(AsyncWebSocketMessageBuffer *buffer) {
   bool enqueued = false;

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -56,88 +56,71 @@ size_t webSocketSendFrameWindow(AsyncClient *client) {
   return space - 8;
 }
 
-size_t webSocketSendFrame(AsyncClient *client, bool final, uint8_t opcode, bool mask, uint8_t *data, size_t len) {
+// wire header length for a frame with this payload length/masking -- pure
+// function of RFC 6455 framing rules, cheap enough to recompute on demand
+// rather than cache
+uint8_t webSocketFrameHeaderLen(size_t payloadLen, bool mask) {
+  return 2 + ((payloadLen && mask) ? 4 : 0) + ((payloadLen > 125) ? 2 : 0);
+}
+
+// Commits any not-yet-committed bytes of one WS frame (header+payload) to
+// the client, resuming from `frameSent` bytes already committed by a prior
+// call for this exact frame. final/opcode/mask/maskKey/data/len must stay
+// identical across calls for the same frame -- once any header byte is
+// committed those values are fixed on the wire and can't change. Returns
+// the number of *additional* bytes committed by this call (0 if none);
+// never assumes an add() fully succeeds, since some AsyncClient backends
+// (e.g. SSL) can commit a genuine partial amount.
+size_t webSocketAddFrame(AsyncClient *client, bool final, uint8_t opcode, bool mask, const uint8_t maskKey[4], uint8_t *data, size_t len, size_t frameSent) {
   if (!client || !client->canSend()) {
-    // Serial.println("SF 1");
-    return 0;
-  }
-  size_t space = client->space();
-  if (space < 2) {
-    // Serial.println("SF 2");
-    return 0;
-  }
-  uint8_t mbuf[4] = {0, 0, 0, 0};
-  uint8_t headLen = 2;
-  if (len && mask) {
-    headLen += 4;
-    mbuf[0] = rand() % 0xFF;  // NOLINT(runtime/threadsafe_fn)
-    mbuf[1] = rand() % 0xFF;  // NOLINT(runtime/threadsafe_fn)
-    mbuf[2] = rand() % 0xFF;  // NOLINT(runtime/threadsafe_fn)
-    mbuf[3] = rand() % 0xFF;  // NOLINT(runtime/threadsafe_fn)
-  }
-  if (len > 125) {
-    headLen += 2;
-  }
-  if (space < headLen) {
-    // Serial.println("SF 2");
-    return 0;
-  }
-  space -= headLen;
-
-  if (len > space) {
-    len = space;
-  }
-
-  uint8_t *buf = (uint8_t *)malloc(headLen);
-  if (buf == NULL) {
-    async_ws_log_e("Failed to allocate");
-    client->abort();
     return 0;
   }
 
-  buf[0] = opcode & 0x0F;
-  if (final) {
-    buf[0] |= 0x80;
-  }
+  const uint8_t headLen = webSocketFrameHeaderLen(len, mask);
+  uint8_t hdr[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+  hdr[0] = (opcode & 0x0F) | (final ? 0x80 : 0);
   if (len < 126) {
-    buf[1] = len & 0x7F;
+    hdr[1] = len & 0x7F;
   } else {
-    buf[1] = 126;
-    buf[2] = (uint8_t)((len >> 8) & 0xFF);
-    buf[3] = (uint8_t)(len & 0xFF);
+    hdr[1] = 126;
+    hdr[2] = (uint8_t)((len >> 8) & 0xFF);
+    hdr[3] = (uint8_t)(len & 0xFF);
   }
   if (len && mask) {
-    buf[1] |= 0x80;
-    memcpy(buf + (headLen - 4), mbuf, 4);
+    hdr[1] |= 0x80;
+    memcpy(hdr + (headLen - 4), maskKey, 4);
   }
-  if (client->add((const char *)buf, headLen) != headLen) {
-    // os_printf("error adding %lu header bytes\n", headLen);
-    free(buf);
-    // Serial.println("SF 4");
-    return 0;
-  }
-  free(buf);
 
-  if (len) {
-    if (len && mask) {
-      size_t i;
-      for (i = 0; i < len; i++) {
-        data[i] = data[i] ^ mbuf[i % 4];
+  size_t committed = 0;
+
+  if (frameSent < headLen) {
+    size_t added = client->add((const char *)(hdr + frameSent), headLen - frameSent);
+    committed += added;
+    frameSent += added;
+    if (frameSent < headLen) {
+      return committed;
+    }
+  }
+
+  const size_t payloadSent = frameSent - headLen;
+  if (payloadSent < len) {
+    const size_t remaining = len - payloadSent;
+    if (mask) {
+      for (size_t i = 0; i < remaining; i++) {
+        data[payloadSent + i] ^= maskKey[(payloadSent + i) % 4];
       }
     }
-    if (client->add((const char *)data, len) != len) {
-      // os_printf("error adding %lu data bytes\n", len);
-      //  Serial.println("SF 5");
-      return 0;
+    size_t added = client->add((const char *)(data + payloadSent), remaining);
+    if (mask && added < remaining) {
+      // undo masking of the unsent tail so a retry masks it correctly from the new offset
+      for (size_t i = added; i < remaining; i++) {
+        data[payloadSent + i] ^= maskKey[(payloadSent + i) % 4];
+      }
     }
+    committed += added;
   }
-  if (!client->send()) {
-    // os_printf("error sending frame: %lu\n", headLen+len);
-    //  Serial.println("SF 6");
-    return 0;
-  }
-  // Serial.println("SF");
-  return len;
+
+  return committed;
 }
 
 /*
@@ -191,24 +174,11 @@ size_t AsyncWebSocketMessage::send(AsyncClient *client) {
     return 0;
   }
 
-  if (isControl()) {
-    // control frames are always a single, unfragmented frame
-    _status = WS_MSG_SENT;
-    return webSocketSendFrame(client, true, _opcode, _mask, (uint8_t *)_WSbuffer->data(), _WSbuffer->size());
-  }
-
   if (_status != WS_MSG_SENDING) {
     async_ws_log_v("SEND[%" PRIu8 "] => [%" PRIu16 "] WS_MSG_SENDING != %" PRIu8, _opcode, client->remotePort(), static_cast<uint8_t>(_status));
     return 0;
   }
 
-  if (_sent == _WSbuffer->size()) {
-    if (_acked == _ack) {
-      _status = WS_MSG_SENT;
-    }
-    async_ws_log_v("SEND[%" PRIu8 "] => [%" PRIu16 "] WS_MSG_SENT %u/%u (acked: %u/%u)", _opcode, client->remotePort(), _sent, _WSbuffer->size(), _acked, _ack);
-    return 0;
-  }
   if (_sent > _WSbuffer->size()) {
     _status = WS_MSG_ERROR;
     async_ws_log_v(
@@ -217,35 +187,64 @@ size_t AsyncWebSocketMessage::send(AsyncClient *client) {
     return 0;
   }
 
-  size_t toSend = _WSbuffer->size() - _sent;
-  const size_t window = webSocketSendFrameWindow(client);
+  // idle between frames: pick the next frame's parameters. isControl() is
+  // always exactly one frame, so `_ack > 0` (a prior frame fully committed)
+  // is what actually distinguishes "done" from "haven't sent the (possibly
+  // zero-length) first frame yet" -- `_sent == size()` alone is ambiguous
+  // for a bare, zero-payload control frame.
+  if (_frameSent == 0 && _framePayloadLen == 0) {
+    if (_sent == _WSbuffer->size() && _ack > 0) {
+      if (isControl() || _acked == _ack) {
+        _status = WS_MSG_SENT;
+      }
+      async_ws_log_v(
+        "SEND[%" PRIu8 "] => [%" PRIu16 "] WS_MSG_SENT %u/%u (acked: %u/%u)", _opcode, client->remotePort(), _sent, _WSbuffer->size(), _acked, _ack
+      );
+      return 0;
+    }
 
-  // not enough space in lwip buffer ?
-  if (!window) {
-    async_ws_log_v("SEND[%" PRIu8 "] => [%" PRIu16 "] NO_SPACE %u", _opcode, client->remotePort(), toSend);
-    return 0;
+    const size_t remaining = _WSbuffer->size() - _sent;
+    if (isControl()) {
+      _framePayloadLen = remaining;
+    } else {
+      const size_t window = webSocketSendFrameWindow(client);
+      if (!window) {
+        async_ws_log_v("SEND[%" PRIu8 "] => [%" PRIu16 "] NO_SPACE %u", _opcode, client->remotePort(), remaining);
+        return 0;
+      }
+      _framePayloadLen = std::min(remaining, window);
+    }
+    if (_mask) {
+      _maskKey[0] = rand() % 0xFF;  // NOLINT(runtime/threadsafe_fn)
+      _maskKey[1] = rand() % 0xFF;  // NOLINT(runtime/threadsafe_fn)
+      _maskKey[2] = rand() % 0xFF;  // NOLINT(runtime/threadsafe_fn)
+      _maskKey[3] = rand() % 0xFF;  // NOLINT(runtime/threadsafe_fn)
+    }
   }
 
-  toSend = std::min(toSend, window);
+  const bool final = isControl() || (_sent + _framePayloadLen == _WSbuffer->size());
+  const uint8_t frameOpcode = (isControl() || _sent == 0) ? _opcode : (uint8_t)WS_CONTINUATION;
 
-  _sent += toSend;
-  _ack += toSend + ((toSend < 126) ? 2 : 4) + (_mask * 4);
+  const size_t added = webSocketAddFrame(client, final, frameOpcode, _mask, _maskKey, (uint8_t *)_WSbuffer->data() + _sent, _framePayloadLen, _frameSent);
+  _frameSent += added;
 
-  bool final = (_sent == _WSbuffer->size());
-  uint8_t *dPtr = (uint8_t *)(_WSbuffer->data() + (_sent - toSend));
-  uint8_t opCode = (toSend && _sent == toSend) ? _opcode : (uint8_t)WS_CONTINUATION;
-
-  size_t sent = webSocketSendFrame(client, final, opCode, _mask, dPtr, toSend);
-  _status = WS_MSG_SENDING;
-  if (toSend && sent != toSend) {
-    _sent -= (toSend - sent);
-    _ack -= (toSend - sent);
+  const size_t frameLen = webSocketFrameHeaderLen(_framePayloadLen, _mask) + _framePayloadLen;
+  if (_frameSent < frameLen) {
+    async_ws_log_v("SEND[%" PRIu8 "] => [%" PRIu16 "] PARTIAL %u/%u", _opcode, client->remotePort(), _frameSent, frameLen);
+    return added;
   }
+
+  // frame fully committed
+  _ack += _frameSent;
+  _sent += _framePayloadLen;
+  _frameSent = 0;
+  _framePayloadLen = 0;
+  client->send();  // idempotent flush; the bytes are already durably queued regardless of outcome
 
   async_ws_log_v(
     "SEND[%" PRIu8 "] => [%" PRIu16 "] WS_MSG_SENDING %u/%u (acked: %u/%u)", _opcode, client->remotePort(), _sent, _WSbuffer->size(), _acked, _ack
   );
-  return sent;
+  return added;
 }
 
 /*

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -283,7 +283,12 @@ void AsyncWebSocketClient::_runQueue(asyncsrv::unique_lock_type &lock) {
     AsyncWebSocketMessage &target = _sendingControl ? _controlQueue.front() : _messageQueue.front();
     const bool final = _sendingControl || (_sent + _framePayloadLen == target.size());
     const uint8_t frameOpcode = (_sendingControl || _sent == 0) ? target.opcode() : (uint8_t)WS_CONTINUATION;
-    uint8_t *payload = target.data() + (_sendingControl ? 0 : _sent);
+    uint8_t *payload = target.data();
+
+    // Avoid UB pointer arithmetic if payload is nullptr
+    if (payload && !_sendingControl) {
+      payload += _sent;
+    }
 
     const size_t added = webSocketAddFrame(_client, final, frameOpcode, target.mask(), _maskKey, payload, _framePayloadLen, _frameSent);
 

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -37,13 +37,13 @@
 
 using namespace asyncsrv;
 
-namespace {
-AsyncWebSocketSharedBuffer makeSharedBuffer(const uint8_t *message, size_t len) {
-  auto buffer = std::make_shared<std::vector<uint8_t>>(len);
-  std::memcpy(buffer->data(), message, len);
-  return buffer;
+static AsyncWebSocketSharedBuffer makeSharedBuffer(const uint8_t *message, size_t len) {
+  if (message) {
+    return std::make_shared<std::vector<uint8_t>>(message, message + len);
+  } else {
+    return std::make_shared<std::vector<uint8_t>>(len);
+  }
 }
-}  // namespace
 
 static size_t webSocketSendFrameWindow(AsyncClient *client) {
   if (!client || !client->canSend()) {

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -150,104 +150,6 @@ bool AsyncWebSocketMessageBuffer::reserve(size_t size) {
 }
 
 /*
- * AsyncWebSocketMessage Message
- */
-
-AsyncWebSocketMessage::AsyncWebSocketMessage(AsyncWebSocketSharedBuffer buffer, uint8_t opcode, bool mask)
-  : _WSbuffer{buffer}, _opcode(opcode & 0x0F), _mask{mask}, _status{_WSbuffer ? WS_MSG_SENDING : WS_MSG_ERROR} {}
-
-size_t AsyncWebSocketMessage::ack(size_t len, uint32_t time) {
-  (void)time;
-  const size_t pending = std::min(len, _ack - _acked);
-  _acked += pending;
-  if (_sent >= _WSbuffer->size() && _acked >= _ack) {
-    _status = WS_MSG_SENT;
-  }
-  const size_t remaining = len - pending;
-  async_ws_log_v("ACK[%" PRIu8 "] %u/%u (acked: %u/%u) => %" PRIu8, _opcode, _sent, _WSbuffer->size(), _acked, _ack, static_cast<uint8_t>(_status));
-  return remaining;
-}
-
-size_t AsyncWebSocketMessage::send(AsyncClient *client) {
-  if (!client) {
-    async_ws_log_v("No client");
-    return 0;
-  }
-
-  if (_status != WS_MSG_SENDING) {
-    async_ws_log_v("SEND[%" PRIu8 "] => [%" PRIu16 "] WS_MSG_SENDING != %" PRIu8, _opcode, client->remotePort(), static_cast<uint8_t>(_status));
-    return 0;
-  }
-
-  if (_sent > _WSbuffer->size()) {
-    _status = WS_MSG_ERROR;
-    async_ws_log_v(
-      "SEND[%" PRIu8 "] => [%" PRIu16 "] WS_MSG_ERROR %u/%u (acked: %u/%u)", _opcode, client->remotePort(), _sent, _WSbuffer->size(), _acked, _ack
-    );
-    return 0;
-  }
-
-  // idle between frames: pick the next frame's parameters. isControl() is
-  // always exactly one frame, so `_ack > 0` (a prior frame fully committed)
-  // is what actually distinguishes "done" from "haven't sent the (possibly
-  // zero-length) first frame yet" -- `_sent == size()` alone is ambiguous
-  // for a bare, zero-payload control frame.
-  if (_frameSent == 0 && _framePayloadLen == 0) {
-    if (_sent == _WSbuffer->size() && _ack > 0) {
-      if (isControl() || _acked == _ack) {
-        _status = WS_MSG_SENT;
-      }
-      async_ws_log_v(
-        "SEND[%" PRIu8 "] => [%" PRIu16 "] WS_MSG_SENT %u/%u (acked: %u/%u)", _opcode, client->remotePort(), _sent, _WSbuffer->size(), _acked, _ack
-      );
-      return 0;
-    }
-
-    const size_t remaining = _WSbuffer->size() - _sent;
-    if (isControl()) {
-      _framePayloadLen = remaining;
-    } else {
-      const size_t window = webSocketSendFrameWindow(client);
-      if (!window) {
-        async_ws_log_v("SEND[%" PRIu8 "] => [%" PRIu16 "] NO_SPACE %u", _opcode, client->remotePort(), remaining);
-        return 0;
-      }
-      _framePayloadLen = std::min(remaining, window);
-    }
-    if (_mask) {
-      _maskKey[0] = rand() % 0xFF;  // NOLINT(runtime/threadsafe_fn)
-      _maskKey[1] = rand() % 0xFF;  // NOLINT(runtime/threadsafe_fn)
-      _maskKey[2] = rand() % 0xFF;  // NOLINT(runtime/threadsafe_fn)
-      _maskKey[3] = rand() % 0xFF;  // NOLINT(runtime/threadsafe_fn)
-    }
-  }
-
-  const bool final = isControl() || (_sent + _framePayloadLen == _WSbuffer->size());
-  const uint8_t frameOpcode = (isControl() || _sent == 0) ? _opcode : (uint8_t)WS_CONTINUATION;
-
-  const size_t added = webSocketAddFrame(client, final, frameOpcode, _mask, _maskKey, (uint8_t *)_WSbuffer->data() + _sent, _framePayloadLen, _frameSent);
-  _frameSent += added;
-
-  const size_t frameLen = webSocketFrameHeaderLen(_framePayloadLen, _mask) + _framePayloadLen;
-  if (_frameSent < frameLen) {
-    async_ws_log_v("SEND[%" PRIu8 "] => [%" PRIu16 "] PARTIAL %u/%u", _opcode, client->remotePort(), _frameSent, frameLen);
-    return added;
-  }
-
-  // frame fully committed
-  _ack += _frameSent;
-  _sent += _framePayloadLen;
-  _frameSent = 0;
-  _framePayloadLen = 0;
-  client->send();  // idempotent flush; the bytes are already durably queued regardless of outcome
-
-  async_ws_log_v(
-    "SEND[%" PRIu8 "] => [%" PRIu16 "] WS_MSG_SENDING %u/%u (acked: %u/%u)", _opcode, client->remotePort(), _sent, _WSbuffer->size(), _acked, _ack
-  );
-  return added;
-}
-
-/*
  * Async WebSocket Client
  */
 const char *AWSC_PING_PAYLOAD = "ESPAsyncWebServer-PING";
@@ -312,25 +214,25 @@ AsyncWebSocketClient::~AsyncWebSocketClient() {
   _server->_handleEvent(this, WS_EVT_DISCONNECT, NULL, NULL, 0);
 }
 
-void AsyncWebSocketClient::_clearQueue() {
-  while (!_messageQueue.empty() && _messageQueue.front().finished()) {
-    _messageQueue.pop_front();
-  }
-}
-
 void AsyncWebSocketClient::_onAck(size_t len, uint32_t time) {
+  (void)time;
   _lastMessageTime = millis();
 
   asyncsrv::unique_lock_type lock(_queue_lock);
 
-  async_ws_log_v("[%s][%" PRIu32 "] START ACK(%u, %" PRIu32 ") Q:%u", _server->url(), _clientId, len, time, _messageQueue.size());
+  async_ws_log_v("[%s][%" PRIu32 "] ACK(%u) unacked:%u", _server->url(), _clientId, len, _unacked);
 
-  if (!_controlQueue.empty()) {
-    auto &head = _controlQueue.front();
-    if (head.finished()) {
-      len -= head.len();
-      if (_status == WS_DISCONNECTING && head.opcode() == WS_DISCONNECT) {
-        _controlQueue.pop_front();
+  // exactly one frame can ever be outstanding, so a single clamped
+  // subtraction is all the ack accounting this needs
+  const bool wasAwaitingAck = (_frameSent == 0 && _unacked > 0);
+  _unacked -= std::min(len, _unacked);
+
+  if (wasAwaitingAck && _unacked == 0) {
+    // the in-flight frame is now fully sent and fully acked
+    if (_sendingControl && !_controlQueue.empty()) {
+      const uint8_t opcode = _controlQueue.front().opcode();
+      _controlQueue.pop_front();
+      if (_status == WS_DISCONNECTING && opcode == WS_DISCONNECT) {
         _status = WS_DISCONNECTED;
         async_ws_log_v("[%s][%" PRIu32 "] ACK WS_DISCONNECTED", _server->url(), _clientId);
         // Capture _client before unlocking: _client->close() triggers the _onDisconnect() --> _handleDisconnect() --> ~AsyncWebSocketClient() chain,
@@ -342,22 +244,11 @@ void AsyncWebSocketClient::_onAck(size_t len, uint32_t time) {
         }
         return;
       }
-      _controlQueue.pop_front();
+    } else if (!_sendingControl && !_messageQueue.empty() && _sent >= _messageQueue.front().size()) {
+      _messageQueue.pop_front();
+      _sent = 0;
     }
   }
-
-  if (len && !_messageQueue.empty()) {
-    for (auto &msg : _messageQueue) {
-      len = msg.ack(len, time);
-      if (len == 0) {
-        break;
-      }
-    }
-  }
-
-  _clearQueue();
-
-  async_ws_log_v("[%s][%" PRIu32 "] END ACK(%u, %" PRIu32 ") Q:%u", _server->url(), _clientId, len, time, _messageQueue.size());
 
   _runQueue();
 }
@@ -383,56 +274,64 @@ void AsyncWebSocketClient::_runQueue() {
     return;
   }
 
-  _clearQueue();
-
-  size_t space = webSocketSendFrameWindow(_client);
-
-  if (space) {
-    // control frames have priority over message frames
-    // we can send a control frame if:
-    // - there is no message frame in the queue, or the first message frame is between frames (all bytes sent are acked)
-    // - the control frame is not finished (not sent yet)
-    // - there is enough space to send the control frame (control frames are small, at most 129 bytes, so we can assume that if there is space to send it, it can be sent in one go)
-    if (_messageQueue.empty() || _messageQueue.front().betweenFrames()) {
-      for (auto &ctrl : _controlQueue) {
-        if (ctrl.finished()) {
-          continue;
-        }
-        if (space > (size_t)(ctrl.len() - 1)) {
-          async_ws_log_v("[%s][%" PRIu32 "] SEND CTRL %" PRIu8, _server->url(), _clientId, ctrl.opcode());
-          ctrl.send(_client);
-          space = webSocketSendFrameWindow(_client);
-        }
-      }
+  if (_frameSent == 0) {
+    if (_unacked > 0) {
+      return;  // waiting for the in-flight frame to be acked before starting the next one
     }
 
-    // then we can send message frames if there is space
-    if (space) {
-      for (auto &msg : _messageQueue) {
-        if (msg._remainingBytesToSend()) {
-          async_ws_log_v(
-            "[%s][%" PRIu32 "][%" PRIu8 "] SEND %u/%u (acked: %u/%u)", _server->url(), _clientId, msg._opcode, msg._sent, msg._WSbuffer->size(), msg._acked,
-            msg._ack
-          );
+    // idle: pick the next target by priority (control first)
+    if (!_controlQueue.empty()) {
+      _sendingControl = true;
+    } else if (!_messageQueue.empty()) {
+      _sendingControl = false;
+    } else {
+      return;  // nothing queued
+    }
 
-          // will use all the remaining space, or all the remaining bytes to send, whichever is smaller
-          msg.send(_client);
-          space = webSocketSendFrameWindow(_client);
-
-          // If we haven't finished sending this message, we must stop here to preserve WebSocket ordering.
-          // We can only pipeline subsequent messages if the current one is fully passed to TCP buffer.
-          if (msg._remainingBytesToSend()) {
-            async_ws_log_v("[%s][%" PRIu32 "][%" PRIu8 "] NO_SPACE", _server->url(), _clientId, msg._opcode);
-            break;
-          }
-        } else if (!space) {
-          // not enough space for another message
-          async_ws_log_v("[%s][%" PRIu32 "] NO_SPACE", _server->url(), _clientId);
-          break;
-        }
+    AsyncWebSocketMessage &target = _sendingControl ? _controlQueue.front() : _messageQueue.front();
+    const size_t remaining = target.size() - (_sendingControl ? 0 : _sent);
+    if (_sendingControl) {
+      _framePayloadLen = remaining;
+    } else {
+      const size_t window = webSocketSendFrameWindow(_client);
+      if (!window) {
+        return;
       }
+      _framePayloadLen = std::min(remaining, window);
+    }
+    if (target.mask()) {
+      _maskKey[0] = rand() % 0xFF;  // NOLINT(runtime/threadsafe_fn)
+      _maskKey[1] = rand() % 0xFF;  // NOLINT(runtime/threadsafe_fn)
+      _maskKey[2] = rand() % 0xFF;  // NOLINT(runtime/threadsafe_fn)
+      _maskKey[3] = rand() % 0xFF;  // NOLINT(runtime/threadsafe_fn)
     }
   }
+
+  AsyncWebSocketMessage &target = _sendingControl ? _controlQueue.front() : _messageQueue.front();
+  const bool final = _sendingControl || (_sent + _framePayloadLen == target.size());
+  const uint8_t frameOpcode = (_sendingControl || _sent == 0) ? target.opcode() : (uint8_t)WS_CONTINUATION;
+  uint8_t *payload = target.data() + (_sendingControl ? 0 : _sent);
+
+  async_ws_log_v(
+    "[%s][%" PRIu32 "][%" PRIu8 "] SEND ctrl:%d %u/%u", _server->url(), _clientId, frameOpcode, _sendingControl, _frameSent,
+    webSocketFrameHeaderLen(_framePayloadLen, target.mask()) + _framePayloadLen
+  );
+
+  _frameSent += webSocketAddFrame(_client, final, frameOpcode, target.mask(), _maskKey, payload, _framePayloadLen, _frameSent);
+
+  const size_t frameLen = webSocketFrameHeaderLen(_framePayloadLen, target.mask()) + _framePayloadLen;
+  if (_frameSent < frameLen) {
+    return;  // partial; resume on the next trigger
+  }
+
+  // frame fully committed to TCP -- now waiting for ack
+  _unacked = _frameSent;
+  _frameSent = 0;
+  if (!_sendingControl) {
+    _sent += _framePayloadLen;
+  }
+  _framePayloadLen = 0;
+  _client->send();
 }
 
 bool AsyncWebSocketClient::queueIsFull() const {

--- a/src/AsyncWebSocket.h
+++ b/src/AsyncWebSocket.h
@@ -148,10 +148,10 @@ public:
     return _mask;
   }
   size_t size() const {
-    return _WSbuffer->size();
+    return _WSbuffer ? _WSbuffer->size() : 0U;
   }
   uint8_t *data() const {
-    return _WSbuffer->data();
+    return _WSbuffer ? _WSbuffer->data() : nullptr;
   }
 };
 
@@ -169,22 +169,25 @@ private:
   std::deque<AsyncWebSocketMessage> _messageQueue;
   bool _closeWhenFull = false;
 
-  // Exactly one WS frame may be outstanding (added to TCP but not yet fully
-  // acked) at a time, shared uniformly between control and data frames --
-  // deliberately one set of fields, not one per queue. All are zero/false
-  // when idle (nothing being built, sent, or awaited).
+  // A message is dequeued as soon as it's fully add()'ed to the TCP output
+  // buffer -- delivery is TCP's job from that point on, so there's no ack
+  // bookkeeping here. Only one frame is ever being built/added at a time,
+  // shared uniformly between control and data frames: deliberately one set
+  // of fields, not one per queue. All are zero/false when idle.
   bool _sendingControl{false};  // while non-idle: is the in-flight frame from _controlQueue.front() (true) or _messageQueue.front() (false)?
   size_t _sent{0};              // data messages only: payload bytes of _messageQueue.front() committed across already-completed frames
   uint8_t _maskKey[4]{};        // meaningful only while non-idle and the target message is masked
   size_t _framePayloadLen{0};   // payload length committed to the header of the in-flight frame
   size_t _frameSent{0};         // bytes of (header+in-flight payload) committed so far for the in-flight frame; 0 when idle
-  size_t _unacked{0};           // wire bytes of the in-flight/just-completed frame not yet acked; 0 when idle
 
   AwsFrameInfo _pinfo;
 
   bool _queueControl(uint8_t opcode, const uint8_t *data = NULL, size_t len = 0, bool mask = false);
   bool _queueMessage(AsyncWebSocketSharedBuffer buffer, uint8_t opcode = WS_TEXT, bool mask = false);
-  void _runQueue();
+  // caller must hold _queue_lock via `lock`; _runQueue may unlock() it (e.g.
+  // before a close() that can synchronously destroy *this) and never touch
+  // `this` again afterward -- callers must do the same once this returns.
+  void _runQueue(asyncsrv::unique_lock_type &lock);
 
   // this function is called when a text message is received, in order to copy the buffer and place a null terminator at the end of the buffer for easier handling of text messages.
   // Returns true on success, false on failure (e.g. memory allocation failure)

--- a/src/AsyncWebSocket.h
+++ b/src/AsyncWebSocket.h
@@ -141,9 +141,14 @@ private:
   uint8_t _opcode{WS_TEXT};
   bool _mask{false};
   AwsMessageStatus _status{WS_MSG_ERROR};
-  size_t _sent{};
+  size_t _sent{};  // payload bytes committed across already-completed frames
   size_t _ack{};
   size_t _acked{};
+
+  // in-flight frame state, valid only while a frame is being built/resumed
+  size_t _frameSent{};        // header+payload bytes committed so far for the current frame
+  size_t _framePayloadLen{};  // payload length committed to the current frame's header
+  uint8_t _maskKey[4]{};
 
 public:
   AsyncWebSocketMessage(AsyncWebSocketSharedBuffer buffer, uint8_t opcode = WS_TEXT, bool mask = false);

--- a/src/AsyncWebSocket.h
+++ b/src/AsyncWebSocket.h
@@ -57,60 +57,6 @@ class AsyncWebSocket;
 class AsyncWebSocketResponse;
 class AsyncWebSocketClient;
 
-/*
- * Control Frame
- */
-
-class AsyncWebSocketControl {
-private:
-  uint8_t _opcode;
-  uint8_t *_data;
-  size_t _len;
-  bool _mask;
-  bool _finished;
-
-public:
-  AsyncWebSocketControl(uint8_t opcode, const uint8_t *data = NULL, size_t len = 0, bool mask = false)
-    : _opcode(opcode), _len(len), _mask(len && mask), _finished(false) {
-    if (data == NULL) {
-      _len = 0;
-    }
-    if (_len) {
-      if (_len > 125) {
-        _len = 125;
-      }
-
-      _data = (uint8_t *)malloc(_len);
-
-      if (_data == NULL) {
-        async_ws_log_e("Failed to allocate");
-        _len = 0;
-      } else {
-        memcpy(_data, data, len);
-      }
-    } else {
-      _data = NULL;
-    }
-  }
-
-  ~AsyncWebSocketControl() {
-    if (_data != NULL) {
-      free(_data);
-    }
-  }
-
-  bool finished() const {
-    return _finished;
-  }
-  uint8_t opcode() {
-    return _opcode;
-  }
-  uint8_t len() {
-    return _len + 2;
-  }
-  size_t send(AsyncClient *client);
-};
-
 typedef struct {
   /** Message type as defined by enum AwsFrameType.
      * Note: Applications will only see WS_TEXT and WS_BINARY.
@@ -202,11 +148,21 @@ private:
 public:
   AsyncWebSocketMessage(AsyncWebSocketSharedBuffer buffer, uint8_t opcode = WS_TEXT, bool mask = false);
 
+  bool isControl() const {
+    return _opcode >= WS_DISCONNECT;
+  }
   bool finished() const {
     return _status != WS_MSG_SENDING;
   }
   bool betweenFrames() const {
     return _acked == _ack;
+  }
+  uint8_t opcode() const {
+    return _opcode;
+  }
+  // wire length of a (necessarily unfragmented, unmasked) control frame
+  size_t len() const {
+    return _WSbuffer->size() + 2;
   }
 
   size_t ack(size_t len, uint32_t time);
@@ -223,7 +179,7 @@ private:
   uint32_t _lastMessageTime;
   uint32_t _keepAlivePeriod;
   mutable asyncsrv::mutex_type _queue_lock;
-  std::deque<AsyncWebSocketControl> _controlQueue;
+  std::deque<AsyncWebSocketMessage> _controlQueue;
   std::deque<AsyncWebSocketMessage> _messageQueue;
   bool _closeWhenFull = false;
 

--- a/src/AsyncWebSocket.h
+++ b/src/AsyncWebSocket.h
@@ -95,11 +95,6 @@ typedef enum {
   WS_PONG
 } AwsFrameType;
 typedef enum {
-  WS_MSG_SENDING,
-  WS_MSG_SENT,
-  WS_MSG_ERROR
-} AwsMessageStatus;
-typedef enum {
   WS_EVT_CONNECT,
   WS_EVT_DISCONNECT,
   WS_EVT_PING,
@@ -129,49 +124,35 @@ public:
   }
 };
 
+// Pure payload holder -- no send-progress state. Lives only in
+// AsyncWebSocketClient's _controlQueue/_messageQueue; all in-flight frame
+// tracking lives on the client, since only one frame may be outstanding
+// (added to TCP but not yet acked) across both queues at a time.
 class AsyncWebSocketMessage {
-  friend AsyncWebSocketClient;
-
 private:
-  size_t _remainingBytesToSend() const {
-    return _WSbuffer->size() - _sent;
-  }
-
   AsyncWebSocketSharedBuffer _WSbuffer;
   uint8_t _opcode{WS_TEXT};
   bool _mask{false};
-  AwsMessageStatus _status{WS_MSG_ERROR};
-  size_t _sent{};  // payload bytes committed across already-completed frames
-  size_t _ack{};
-  size_t _acked{};
-
-  // in-flight frame state, valid only while a frame is being built/resumed
-  size_t _frameSent{};        // header+payload bytes committed so far for the current frame
-  size_t _framePayloadLen{};  // payload length committed to the current frame's header
-  uint8_t _maskKey[4]{};
 
 public:
-  AsyncWebSocketMessage(AsyncWebSocketSharedBuffer buffer, uint8_t opcode = WS_TEXT, bool mask = false);
+  AsyncWebSocketMessage(AsyncWebSocketSharedBuffer buffer, uint8_t opcode = WS_TEXT, bool mask = false)
+    : _WSbuffer{buffer}, _opcode(opcode & 0x0F), _mask{mask} {}
 
   bool isControl() const {
     return _opcode >= WS_DISCONNECT;
   }
-  bool finished() const {
-    return _status != WS_MSG_SENDING;
-  }
-  bool betweenFrames() const {
-    return _acked == _ack;
-  }
   uint8_t opcode() const {
     return _opcode;
   }
-  // wire length of a (necessarily unfragmented, unmasked) control frame
-  size_t len() const {
-    return _WSbuffer->size() + 2;
+  bool mask() const {
+    return _mask;
   }
-
-  size_t ack(size_t len, uint32_t time);
-  size_t send(AsyncClient *client);
+  size_t size() const {
+    return _WSbuffer->size();
+  }
+  uint8_t *data() const {
+    return _WSbuffer->data();
+  }
 };
 
 class AsyncWebSocketClient {
@@ -188,12 +169,22 @@ private:
   std::deque<AsyncWebSocketMessage> _messageQueue;
   bool _closeWhenFull = false;
 
+  // Exactly one WS frame may be outstanding (added to TCP but not yet fully
+  // acked) at a time, shared uniformly between control and data frames --
+  // deliberately one set of fields, not one per queue. All are zero/false
+  // when idle (nothing being built, sent, or awaited).
+  bool _sendingControl{false};  // while non-idle: is the in-flight frame from _controlQueue.front() (true) or _messageQueue.front() (false)?
+  size_t _sent{0};              // data messages only: payload bytes of _messageQueue.front() committed across already-completed frames
+  uint8_t _maskKey[4]{};        // meaningful only while non-idle and the target message is masked
+  size_t _framePayloadLen{0};   // payload length committed to the header of the in-flight frame
+  size_t _frameSent{0};         // bytes of (header+in-flight payload) committed so far for the in-flight frame; 0 when idle
+  size_t _unacked{0};           // wire bytes of the in-flight/just-completed frame not yet acked; 0 when idle
+
   AwsFrameInfo _pinfo;
 
   bool _queueControl(uint8_t opcode, const uint8_t *data = NULL, size_t len = 0, bool mask = false);
   bool _queueMessage(AsyncWebSocketSharedBuffer buffer, uint8_t opcode = WS_TEXT, bool mask = false);
   void _runQueue();
-  void _clearQueue();
 
   // this function is called when a text message is received, in order to copy the buffer and place a null terminator at the end of the buffer for easier handling of text messages.
   // Returns true on success, false on failure (e.g. memory allocation failure)


### PR DESCRIPTION
The more-complete websocket output refactor: handle partial frame sends safely, so we can resume where we left off at the next opportunity.

There's a few key changes:
- `AsyncWebSocketControl` was folded in to `AsyncWebSocketMessage`; both performed the same fundamental task.
- Send state was moved to the `AsyncClient` object, instead of being held on every message.
- Messages are dequeued as soon as they are delivered to the TCP buffers -- there's no need to wait for acks.  This improves overall latency and reduces the RAM requirements.
- I expanded the pong handling so I could double check RTTs and ensure control frames can still be injected inside large split data frames.
- I've also borrowed @mathieucarbou 's fixes to the other allocation failure paths.