### PR TITLE
feat: opt-in ASYNCWEBSERVER_USE_PSRAM - allocate handler objects in PSRAM (ESP32)

### DIFF
--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -10,6 +10,10 @@
 #include <lwip/tcpbase.h>
 #endif
 
+#if defined(ESP32) && defined(ASYNCWEBSERVER_USE_PSRAM)
+#include <esp_heap_caps.h>
+#endif
+
 #include <algorithm>
 #include <deque>
 #include <functional>
@@ -1528,6 +1532,26 @@ protected:
 public:
   AsyncWebHandler() {}
   virtual ~AsyncWebHandler() {}
+#if defined(ESP32) && defined(ASYNCWEBSERVER_USE_PSRAM)
+  // Opt-in (-D ASYNCWEBSERVER_USE_PSRAM): allocate handler objects in PSRAM
+  // to preserve scarce internal SRAM. All handlers derive from this base
+  // (route handlers, catch-all, AsyncWebSocket, static file handlers), they
+  // are created after PSRAM is initialized and are only read during request
+  // dispatch - never from an ISR or DMA context - so external RAM is safe
+  // and the added latency is irrelevant. Falls back to the internal heap
+  // when PSRAM is absent or exhausted, so the flag is safe to set on
+  // targets without PSRAM as well.
+  void *operator new(size_t size) {
+    void *p = heap_caps_malloc(size, MALLOC_CAP_SPIRAM);
+    if (!p) {
+      p = malloc(size);
+    }
+    return p;
+  }
+  void operator delete(void *ptr) {
+    heap_caps_free(ptr);  // valid for both PSRAM and internal allocations
+  }
+#endif
   AsyncWebHandler &setFilter(ArRequestFilterFunction fn);
   AsyncWebHandler &setAuthentication(const char *username, const char *password, AsyncAuthType authMethod = AsyncAuthType::AUTH_DIGEST);
   AsyncWebHandler &setAuthentication(const String &username, const String &password, AsyncAuthType authMethod = AsyncAuthType::AUTH_DIGEST) {


### PR DESCRIPTION
On ESP32 targets with PSRAM, internal SRAM is often the scarcest resource (lwIP segments, WiFi buffers, WS message queues all live there). Every AsyncWebHandler-derived object (route handlers, catch-all, AsyncWebSocket, static file handlers) currently comes from the internal heap, though handlers are created once after PSRAM init and only read during request dispatch — never from ISR/DMA context, and latency is irrelevant for them.

This PR adds an opt-in build flag -D ASYNCWEBSERVER_USE_PSRAM that routes handler allocation through heap_caps_malloc(MALLOC_CAP_SPIRAM) with a transparent fallback to the internal heap, so it is safe even on targets without PSRAM. Without the flag, behavior is bit-identical to today — no risk for existing users.

Context: we run a dashboard-heavy ESP32-S3 firmware (same field setup that produced #453) where internal SRAM exhaustion cascades into WiFi/ESP-NOW allocation failures. Moving handlers out of internal RAM is one of the mitigations we have been running in production since mid-July.