### PR TITLE
Add HTTP method constraint for categorizing SSE requests

### DIFF
--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -668,7 +668,7 @@ bool AsyncWebServerRequest::_parseReqHeader() {
 #else
       const char *substr = std::strstr(lowcase.c_str(), String(T_text_event_stream).c_str());
 #endif
-      if (substr != NULL) {
+      if (substr != NULL && _method == AsyncWebRequestMethod::HTTP_GET) {
         // WebEvent request can be uniquely identified by header:  [Accept: text/event-stream]
         _reqconntype = RCT_EVENT;
       }

--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -659,7 +659,13 @@ bool AsyncWebServerRequest::_parseReqHeader() {
       }
     } else if (name.equalsIgnoreCase(T_UPGRADE) && value.equalsIgnoreCase(T_WS)) {
       // WebSocket request can be uniquely identified by header: [Upgrade: websocket]
-      _reqconntype = RCT_WS;
+      // Per RFC 6455 §4.1 the handshake is a GET.  Only classify when the
+      // connection is still a plain HTTP connection so a previously detected
+      // SSE request (or any other classified type) cannot be clobbered by
+      // header ordering.
+      if (_method == AsyncWebRequestMethod::HTTP_GET && (_reqconntype == RCT_DEFAULT || _reqconntype == RCT_HTTP)) {
+        _reqconntype = RCT_WS;
+      }
     } else if (name.equalsIgnoreCase(T_ACCEPT)) {
       String lowcase(value);
       lowcase.toLowerCase();
@@ -668,7 +674,11 @@ bool AsyncWebServerRequest::_parseReqHeader() {
 #else
       const char *substr = std::strstr(lowcase.c_str(), String(T_text_event_stream).c_str());
 #endif
-      if (substr != NULL && _method == AsyncWebRequestMethod::HTTP_GET) {
+      // Server-Sent Events (HTML §9.2) are GET-only connections negotiated via
+      // Accept: text/event-stream.  Only classify when the connection is still
+      // a plain HTTP connection so a previously detected WebSocket upgrade
+      // cannot be clobbered by header ordering.
+      if (substr != NULL && _method == AsyncWebRequestMethod::HTTP_GET && (_reqconntype == RCT_DEFAULT || _reqconntype == RCT_HTTP)) {
         // WebEvent request can be uniquely identified by header:  [Accept: text/event-stream]
         _reqconntype = RCT_EVENT;
       }


### PR DESCRIPTION
### Problem
In `ESPAsyncWebServer.h:586`, the `isSSE` method is true only if the HTTP method is a `GET` request and the `_reqconntype` is `RCT_EVENT`.

```cpp
bool isSSE() const {
  return _method == AsyncWebRequestMethod::HTTP_GET && isExpectedRequestedConnType(RCT_EVENT);
}
```

However, `WebRequest.cpp:671`'s header parsing matches SSE to `Accept: text/event-stream`, regardless of the HTTP method used. If a request uses the `POST` method while still including `text/event-stream` in the Accept header, it will be classified as an `RCT_EVENT`, but fails to match `isSSE` since it is not a `GET` request, causing it to miss any HTTP handlers for that endpoint

### Example
A `POST` request to `/mcp` with the header `Accept: application/json, text/event-stream` will end up being routed by the not found handler, because `_reqconntype` gets set to `RCT_EVENT` from the `Accept` header, regardless of HTTP method. But, `isHTTP` only accepts `RCT_DEFAULT` and `RCT_HTTP`, and `isSSE` requires `GET`, so the request satisfies neither. 

```cpp
server.on("/mcp", HTTP_POST, [](AsyncWebServerRequest* r) {
    r->send(200, "text/plain", "OK");
});
```

### Fix
Added an additional condition to the header-parsing logic in `WebRequest.cpp`, requiring that the request method must be `GET` in addition to the presence of `Accept: text/event-stream`. 