### PR TITLE
Removing dead code for RequestedConnectionType

### DIFF
--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -361,9 +361,7 @@ public:
   AsyncWebHeader(const char *name, const char *value) : _name(name), _value(value) {}
   AsyncWebHeader(const String &name, const String &value) : _name(name), _value(value) {}
 
-#ifndef ESP8266
   [[deprecated("Use AsyncWebHeader::parse(data) instead")]]
-#endif
   AsyncWebHeader(const String &data)
     : AsyncWebHeader(parse(data)){};
 
@@ -575,15 +573,11 @@ public:
   RequestedConnectionType requestedConnType() const {
     return _reqconntype;
   }
-#ifndef ESP8266
   [[deprecated("Use isExpectedRequestedConnType(RequestedConnectionType) instead")]]
-#endif
   bool isExpectedRequestedConnType(RequestedConnectionType erct1, RequestedConnectionType erct2, RequestedConnectionType erct3) const {
     return isExpectedRequestedConnType(erct1) || isExpectedRequestedConnType(erct2) || isExpectedRequestedConnType(erct3);
   }
-#ifndef ESP8266
   [[deprecated("Use isExpectedRequestedConnType(RequestedConnectionType) instead")]]
-#endif
   bool isExpectedRequestedConnType(RequestedConnectionType erct1, RequestedConnectionType erct2) const {
     return isExpectedRequestedConnType(erct1) || isExpectedRequestedConnType(erct2);
   }
@@ -631,16 +625,10 @@ public:
     _handler = handler;
   }
 
-#ifndef ESP8266
   [[deprecated("All headers are now collected. Use removeHeader(name) or AsyncHeaderFreeMiddleware if you really need to free some headers.")]]
-#endif
-  void addInterestingHeader(__asyncws_unused const char *name) {
-  }
-#ifndef ESP8266
+  void addInterestingHeader(__asyncws_unused const char *name) {}
   [[deprecated("All headers are now collected. Use removeHeader(name) or AsyncHeaderFreeMiddleware if you really need to free some headers.")]]
-#endif
-  void addInterestingHeader(__asyncws_unused const String &name) {
-  }
+  void addInterestingHeader(__asyncws_unused const String &name) {}
 
   /**
      * @brief issue HTTP redirect response with Location header
@@ -712,9 +700,7 @@ public:
     send(beginChunkedResponse(contentType, callback, templateCallback));
   }
 
-#ifndef ESP8266
   [[deprecated("Replaced by send(int code, const String& contentType, const uint8_t* content, size_t len, AwsTemplateProcessor callback = nullptr)")]]
-#endif
   void send_P(int code, const String &contentType, const uint8_t *content, size_t len, AwsTemplateProcessor callback = nullptr) {
     send(code, contentType, content, len, callback);
   }
@@ -779,16 +765,12 @@ public:
     return beginResponseStream(contentType.c_str(), bufferSize);
   }
 
-#ifndef ESP8266
   [[deprecated("Replaced by beginResponse(int code, const String& contentType, const uint8_t* content, size_t len, AwsTemplateProcessor callback = nullptr)")]]
-#endif
   AsyncWebServerResponse *beginResponse_P(int code, const String &contentType, const uint8_t *content, size_t len, AwsTemplateProcessor callback = nullptr) {
     return beginResponse(code, contentType.c_str(), content, len, callback);
   }
-#ifndef ESP8266
   [[deprecated("Replaced by beginResponse(int code, const String& contentType, const char* content = asyncsrv::empty, AwsTemplateProcessor callback = nullptr)"
   )]]
-#endif
   AsyncWebServerResponse *beginResponse_P(int code, const String &contentType, PGM_P content, AwsTemplateProcessor callback = nullptr);
 
   /**
@@ -1448,9 +1430,7 @@ public:
     _maxAge = seconds;
   }
 
-#ifndef ESP8266
   [[deprecated("Use instead: addCORSHeaders(AsyncWebServerRequest *request, AsyncWebServerResponse *response)")]]
-#endif
   void addCORSHeaders(AsyncWebServerResponse *response) {
     addCORSHeaders(nullptr, response);
   }
@@ -1644,9 +1624,7 @@ public:
     return _headers;
   }
 
-#ifndef ESP8266
   [[deprecated("Use instead: _assembleHead(String& buffer, uint8_t version)")]]
-#endif
   String _assembleHead(uint8_t version) {
     String buffer;
     _assembleHead(buffer, version);
@@ -1690,9 +1668,7 @@ class AsyncCallbackJsonWebHandler;
 typedef std::function<void(AsyncWebServerRequest *request, JsonVariant &json)> ArJsonRequestHandlerFunction;
 
 #if ASYNC_MSG_PACK_SUPPORT == 1
-#ifndef ESP8266
 [[deprecated("Replaced by AsyncCallbackJsonWebHandler")]]
-#endif
 typedef AsyncCallbackJsonWebHandler AsyncCallbackMessagePackWebHandler;
 #endif  // ASYNC_MSG_PACK_SUPPORT
 

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -395,12 +395,9 @@ public:
  * */
 
 typedef enum {
-  RCT_NOT_USED = -1,
-  RCT_DEFAULT = 0,
-  RCT_HTTP,
-  RCT_WS,
-  RCT_EVENT,
-  RCT_MAX
+  RCT_HTTP = 1,
+  RCT_WS = 2,
+  RCT_EVENT = 3
 } RequestedConnectionType;
 
 // this enum is similar to Arduino WebServer's AsyncAuthType and PsychicHttp
@@ -578,8 +575,22 @@ public:
   RequestedConnectionType requestedConnType() const {
     return _reqconntype;
   }
-  bool isExpectedRequestedConnType(RequestedConnectionType erct1, RequestedConnectionType erct2 = RCT_NOT_USED, RequestedConnectionType erct3 = RCT_NOT_USED)
-    const;
+#ifndef ESP8266
+  [[deprecated("Use isExpectedRequestedConnType(RequestedConnectionType) instead")]]
+#endif
+  bool isExpectedRequestedConnType(RequestedConnectionType erct1, RequestedConnectionType erct2, RequestedConnectionType erct3) const {
+    return isExpectedRequestedConnType(erct1) || isExpectedRequestedConnType(erct2) || isExpectedRequestedConnType(erct3);
+  }
+#ifndef ESP8266
+  [[deprecated("Use isExpectedRequestedConnType(RequestedConnectionType) instead")]]
+#endif
+  bool isExpectedRequestedConnType(RequestedConnectionType erct1, RequestedConnectionType erct2) const {
+    return isExpectedRequestedConnType(erct1) || isExpectedRequestedConnType(erct2);
+  }
+  bool isExpectedRequestedConnType(RequestedConnectionType type) const {
+    return _reqconntype == type;
+  }
+
   bool isWebSocketUpgrade() const {
     return _method == AsyncWebRequestMethod::HTTP_GET && isExpectedRequestedConnType(RCT_WS);
   }
@@ -587,8 +598,9 @@ public:
     return _method == AsyncWebRequestMethod::HTTP_GET && isExpectedRequestedConnType(RCT_EVENT);
   }
   bool isHTTP() const {
-    return isExpectedRequestedConnType(RCT_DEFAULT, RCT_HTTP);
+    return isExpectedRequestedConnType(RCT_HTTP);
   }
+
   void onDisconnect(ArDisconnectHandler fn);
 
   // hash is the string representation of:

--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -663,7 +663,7 @@ bool AsyncWebServerRequest::_parseReqHeader() {
       // connection is still a plain HTTP connection so a previously detected
       // SSE request (or any other classified type) cannot be clobbered by
       // header ordering.
-      if (_method == AsyncWebRequestMethod::HTTP_GET && (_reqconntype == RCT_DEFAULT || _reqconntype == RCT_HTTP)) {
+      if (_method == AsyncWebRequestMethod::HTTP_GET && _reqconntype == RCT_HTTP) {
         _reqconntype = RCT_WS;
       }
     } else if (name.equalsIgnoreCase(T_ACCEPT)) {
@@ -678,7 +678,7 @@ bool AsyncWebServerRequest::_parseReqHeader() {
       // Accept: text/event-stream.  Only classify when the connection is still
       // a plain HTTP connection so a previously detected WebSocket upgrade
       // cannot be clobbered by header ordering.
-      if (substr != NULL && _method == AsyncWebRequestMethod::HTTP_GET && (_reqconntype == RCT_DEFAULT || _reqconntype == RCT_HTTP)) {
+      if (substr != NULL && _method == AsyncWebRequestMethod::HTTP_GET && _reqconntype == RCT_HTTP) {
         // WebEvent request can be uniquely identified by header:  [Accept: text/event-stream]
         _reqconntype = RCT_EVENT;
       }
@@ -1469,18 +1469,11 @@ String AsyncWebServerRequest::urlDecode(const String &text) const {
 
 const char *AsyncWebServerRequest::requestedConnTypeToString() const {
   switch (_reqconntype) {
-    case RCT_NOT_USED: return T_RCT_NOT_USED;
-    case RCT_DEFAULT:  return T_RCT_DEFAULT;
-    case RCT_HTTP:     return T_RCT_HTTP;
-    case RCT_WS:       return T_RCT_WS;
-    case RCT_EVENT:    return T_RCT_EVENT;
-    default:           return T_ERROR;
+    case RCT_HTTP:  return T_RCT_HTTP;
+    case RCT_WS:    return T_RCT_WS;
+    case RCT_EVENT: return T_RCT_EVENT;
+    default:        return T_ERROR;
   }
-}
-
-bool AsyncWebServerRequest::isExpectedRequestedConnType(RequestedConnectionType erct1, RequestedConnectionType erct2, RequestedConnectionType erct3) const {
-  return ((erct1 != RCT_NOT_USED) && (erct1 == _reqconntype)) || ((erct2 != RCT_NOT_USED) && (erct2 == _reqconntype))
-         || ((erct3 != RCT_NOT_USED) && (erct3 == _reqconntype));
 }
 
 AsyncClient *AsyncWebServerRequest::clientRelease() {

--- a/src/literals.h
+++ b/src/literals.h
@@ -139,8 +139,6 @@ static constexpr const char T_LINK[] = "LINK";
 static constexpr const char T_UNLINK[] = "UNLINK";
 
 // Req content types
-static constexpr const char T_RCT_NOT_USED[] = "RCT_NOT_USED";
-static constexpr const char T_RCT_DEFAULT[] = "RCT_DEFAULT";
 static constexpr const char T_RCT_HTTP[] = "RCT_HTTP";
 static constexpr const char T_RCT_WS[] = "RCT_WS";
 static constexpr const char T_RCT_EVENT[] = "RCT_EVENT";


### PR DESCRIPTION
- RCT_NOT_USED unused only as a placeholder as a default param value
- RCT_DEFAULT was partly mean RCT_HTTP but was never assigned, so hardly usable from user code.
- RCT_MAX: unused also